### PR TITLE
Add desiredMotion property to seperate gameplay velocity decisions from physics constraints

### DIFF
--- a/src/boat.ts
+++ b/src/boat.ts
@@ -1,5 +1,5 @@
 import { quat, vec3 } from "./gl-matrix.js";
-import { MotionProps } from "./phys_motion.js";
+import { MotionProps, VelocityProps } from "./phys_motion.js";
 
 export interface BoatProps {
   speed: number;
@@ -17,6 +17,7 @@ export interface BoatObj {
   id: number;
   boat: BoatProps;
   motion: MotionProps;
+  desiredMotion: VelocityProps;
 }
 
 export function stepBoats(objDict: Record<number, BoatObj>, dt: number) {
@@ -24,20 +25,27 @@ export function stepBoats(objDict: Record<number, BoatObj>, dt: number) {
 
   for (let o of objs) {
     // TODO(@darzu): IMPLEMENT
-    // o.motion.linearVelocity[0] = o.boat.speed;
+    // o.desiredMotion.linearVelocity[0] = o.boat.speed;
 
     // TODO(@darzu): hack to init boat direction
-    if (vec3.exactEquals(o.motion.linearVelocity, [0, 0, 0]))
-      o.motion.linearVelocity[0] = 1.0;
+    if (vec3.exactEquals(o.desiredMotion.linearVelocity, [0, 0, 0]))
+      o.desiredMotion.linearVelocity[0] = 1.0;
 
-    vec3.normalize(o.motion.linearVelocity, o.motion.linearVelocity);
-    vec3.scale(o.motion.linearVelocity, o.motion.linearVelocity, o.boat.speed);
+    vec3.normalize(
+      o.desiredMotion.linearVelocity,
+      o.desiredMotion.linearVelocity
+    );
+    vec3.scale(
+      o.desiredMotion.linearVelocity,
+      o.desiredMotion.linearVelocity,
+      o.boat.speed
+    );
 
     const rad = o.boat.wheelDir * dt;
 
     vec3.rotateY(
-      o.motion.linearVelocity,
-      o.motion.linearVelocity,
+      o.desiredMotion.linearVelocity,
+      o.desiredMotion.linearVelocity,
       [0, 0, 0],
       rad
     );

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,13 +29,13 @@ import { jitter } from "./math.js";
 import { createPlayerProps, PlayerProps, stepPlayer } from "./player.js";
 import { never } from "./util.js";
 import { createInputsReader, Inputs } from "./inputs.js";
-import { copyMotionProps, MotionProps } from "./phys_motion.js";
+import { copyMotionProps, MotionProps, VelocityProps } from "./phys_motion.js";
 
 const FORCE_WEBGL = false;
 const MAX_MESHES = 20000;
 const MAX_VERTICES = 21844;
 const ENABLE_NET = true;
-const AUTOSTART = false;
+const AUTOSTART = true;
 
 enum ObjectType {
   Plane,
@@ -419,7 +419,7 @@ class CubeGameState extends GameState {
           Math.random() * -10 - 5
         );
         b.color = vec3.fromValues(Math.random(), Math.random(), Math.random());
-        b.motion.linearVelocity[1] = -0.03;
+        b.desiredMotion.linearVelocity[1] = -0.03;
         this.addObject(b);
         // TODO(@darzu): debug
         console.log(`box: ${b.id}`);
@@ -478,6 +478,8 @@ class CubeGameState extends GameState {
   spawnBullet(motion: MotionProps) {
     let bullet = new Bullet(this.newId(), this.me);
     copyMotionProps(bullet.motion, motion);
+    vec3.copy(bullet.desiredMotion.linearVelocity, motion.linearVelocity);
+    vec3.copy(bullet.desiredMotion.angularVelocity, motion.angularVelocity);
     this.addObjectInstance(bullet, this.bulletProto);
   }
 

--- a/src/phys.ts
+++ b/src/phys.ts
@@ -9,11 +9,11 @@ import {
   resetCollidesWithSet,
 } from "./phys_broadphase.js";
 import {
-  checkAtRest,
   copyMotionProps,
   createMotionProps,
   MotionProps,
   moveObjects,
+  VelocityProps,
 } from "./phys_motion.js";
 import { __isSMI } from "./util.js";
 import { vec3Dbg } from "./utils-3d.js";
@@ -29,6 +29,7 @@ export interface PhysicsObjectUninit {
 export interface PhysicsObject {
   id: number;
   motion: MotionProps;
+  desiredMotion: VelocityProps;
   lastMotion: MotionProps;
   localAABB: AABB;
   worldAABB: AABB;

--- a/src/player.ts
+++ b/src/player.ts
@@ -3,7 +3,11 @@
 import { quat, vec3 } from "./gl-matrix.js";
 import { Inputs } from "./inputs.js";
 import { CameraProps } from "./main.js";
-import { createMotionProps, MotionProps } from "./phys_motion.js";
+import {
+  createMotionProps,
+  MotionProps,
+  VelocityProps,
+} from "./phys_motion.js";
 
 export interface PlayerProps {
   jumpSpeed: number;
@@ -21,6 +25,7 @@ export interface PlayerObj {
   id: number;
   player: PlayerProps;
   motion: MotionProps;
+  desiredMotion: VelocityProps;
 }
 
 export function stepPlayer(
@@ -31,7 +36,7 @@ export function stepPlayer(
   spawnBullet: (motion: MotionProps) => void
 ) {
   // fall with gravity
-  player.motion.linearVelocity[1] -= player.player.gravity * dt;
+  player.desiredMotion.linearVelocity[1] -= player.player.gravity * dt;
 
   // move player
   let vel = vec3.fromValues(0, 0, 0);
@@ -56,16 +61,16 @@ export function stepPlayer(
   //   vec3.add(vel, vel, vec3.fromValues(0, -n, 0));
   // }
   if (inputs.keyClicks[" "]) {
-    player.motion.linearVelocity[1] = player.player.jumpSpeed * dt;
+    player.desiredMotion.linearVelocity[1] = player.player.jumpSpeed * dt;
   }
 
   vec3.transformQuat(vel, vel, player.motion.rotation);
 
-  // vec3.add(player.motion.linearVelocity, player.motion.linearVelocity, vel);
+  // vec3.add(player.desiredMotion.linearVelocity, player.desiredMotion.linearVelocity, vel);
 
   // x and z from local movement
-  player.motion.linearVelocity[0] = vel[0];
-  player.motion.linearVelocity[2] = vel[2];
+  player.desiredMotion.linearVelocity[0] = vel[0];
+  player.desiredMotion.linearVelocity[2] = vel[2];
 
   quat.rotateY(
     player.motion.rotation,

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,6 +7,7 @@ import {
   copyMotionProps,
   createMotionProps,
   MotionProps,
+  VelocityProps,
 } from "./phys_motion.js";
 import { CollidesWith, ReboundData, IdPair, stepPhysics } from "./phys.js";
 import { Inputs } from "./inputs.js";
@@ -57,6 +58,7 @@ export abstract class GameObject {
   // physics
   motion: MotionProps;
   lastMotion?: MotionProps;
+  desiredMotion: VelocityProps;
   localAABB: AABB;
   worldAABB: AABB;
   motionAABB: AABB;
@@ -69,12 +71,15 @@ export abstract class GameObject {
   constructor(id: number, creator: number) {
     this.id = id;
     this.creator = creator;
+    this.desiredMotion = {
+      linearVelocity: vec3.fromValues(0, 0, 0),
+      angularVelocity: vec3.fromValues(0, 0, 0),
+    };
     this.motion = createMotionProps({
       location: vec3.fromValues(0, 0, 0),
       rotation: quat.identity(quat.create()),
       linearVelocity: vec3.fromValues(0, 0, 0),
       angularVelocity: vec3.fromValues(0, 0, 0),
-      atRest: false,
     });
     this.lastMotion = undefined;
     this.authority = creator;


### PR DESCRIPTION
Still a little torn about the seperation.
There are some akward things.
Originally I tried having a desired location and rotation property too.
But the issue is that the physics system needs to move objects forward, and if the desired locations aren't updated by this then the objects never move. If physics updates those properties, then there is bidirectional reading and writing of desiredMotion by both physics and gameplay so there seems like no point in keeping them separate.
So right now desiredMotion just has velocities.
But it might change.