### PR TITLE
trying removing desiredMotion all together

### DIFF
--- a/src/boat.ts
+++ b/src/boat.ts
@@ -1,5 +1,5 @@
 import { quat, vec3 } from "./gl-matrix.js";
-import { MotionProps, VelocityProps } from "./phys_motion.js";
+import { MotionProps } from "./phys_motion.js";
 
 export interface BoatProps {
   speed: number;
@@ -17,7 +17,6 @@ export interface BoatObj {
   id: number;
   boat: BoatProps;
   motion: MotionProps;
-  desiredMotion: VelocityProps;
 }
 
 export function stepBoats(objDict: Record<number, BoatObj>, dt: number) {
@@ -25,27 +24,20 @@ export function stepBoats(objDict: Record<number, BoatObj>, dt: number) {
 
   for (let o of objs) {
     // TODO(@darzu): IMPLEMENT
-    // o.desiredMotion.linearVelocity[0] = o.boat.speed;
+    // o.motion.linearVelocity[0] = o.boat.speed;
 
     // TODO(@darzu): hack to init boat direction
-    if (vec3.exactEquals(o.desiredMotion.linearVelocity, [0, 0, 0]))
-      o.desiredMotion.linearVelocity[0] = 1.0;
+    if (vec3.exactEquals(o.motion.linearVelocity, [0, 0, 0]))
+      o.motion.linearVelocity[0] = 1.0;
 
-    vec3.normalize(
-      o.desiredMotion.linearVelocity,
-      o.desiredMotion.linearVelocity
-    );
-    vec3.scale(
-      o.desiredMotion.linearVelocity,
-      o.desiredMotion.linearVelocity,
-      o.boat.speed
-    );
+    vec3.normalize(o.motion.linearVelocity, o.motion.linearVelocity);
+    vec3.scale(o.motion.linearVelocity, o.motion.linearVelocity, o.boat.speed);
 
     const rad = o.boat.wheelDir * dt;
 
     vec3.rotateY(
-      o.desiredMotion.linearVelocity,
-      o.desiredMotion.linearVelocity,
+      o.motion.linearVelocity,
+      o.motion.linearVelocity,
       [0, 0, 0],
       rad
     );

--- a/src/boat.ts
+++ b/src/boat.ts
@@ -3,12 +3,14 @@ import { MotionProps } from "./phys_motion.js";
 
 export interface BoatProps {
   speed: number;
+  wheelSpeed: number;
   wheelDir: number;
 }
 
 export function createBoatProps(): BoatProps {
   return {
     speed: 0,
+    wheelSpeed: 0,
     wheelDir: 0,
   };
 }
@@ -23,25 +25,18 @@ export function stepBoats(objDict: Record<number, BoatObj>, dt: number) {
   const objs = Object.values(objDict);
 
   for (let o of objs) {
-    // TODO(@darzu): IMPLEMENT
-    // o.motion.linearVelocity[0] = o.boat.speed;
+    const rad = o.boat.wheelSpeed * dt;
+    o.boat.wheelDir += rad;
 
-    // TODO(@darzu): hack to init boat direction
-    if (vec3.exactEquals(o.motion.linearVelocity, [0, 0, 0]))
-      o.motion.linearVelocity[0] = 1.0;
+    // rotate
+    quat.rotateY(o.motion.rotation, o.motion.rotation, rad);
 
-    vec3.normalize(o.motion.linearVelocity, o.motion.linearVelocity);
-    vec3.scale(o.motion.linearVelocity, o.motion.linearVelocity, o.boat.speed);
-
-    const rad = o.boat.wheelDir * dt;
-
+    // rotate velocity
     vec3.rotateY(
       o.motion.linearVelocity,
-      o.motion.linearVelocity,
+      [o.boat.speed, 0, 0],
       [0, 0, 0],
-      rad
+      o.boat.wheelDir
     );
-
-    quat.rotateY(o.motion.rotation, o.motion.rotation, rad);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ import { jitter } from "./math.js";
 import { createPlayerProps, PlayerProps, stepPlayer } from "./player.js";
 import { never } from "./util.js";
 import { createInputsReader, Inputs } from "./inputs.js";
-import { copyMotionProps, MotionProps, VelocityProps } from "./phys_motion.js";
+import { copyMotionProps, MotionProps } from "./phys_motion.js";
 
 const FORCE_WEBGL = false;
 const MAX_MESHES = 20000;
@@ -279,13 +279,13 @@ class Player extends Cube {
       this.snapLocation(location);
     }
     buffer.readVec3(this.motion.linearVelocity);
-    vec3.copy(this.desiredMotion.linearVelocity, this.motion.linearVelocity);
+    vec3.copy(this.motion.linearVelocity, this.motion.linearVelocity);
     let rotation = buffer.readQuat()!;
     if (!buffer.dummy) {
       this.snapRotation(rotation);
     }
     buffer.readVec3(this.motion.angularVelocity);
-    vec3.copy(this.desiredMotion.angularVelocity, this.motion.angularVelocity);
+    vec3.copy(this.motion.angularVelocity, this.motion.angularVelocity);
   }
 
   serializeDynamic(buffer: Serializer) {
@@ -427,7 +427,7 @@ class CubeGameState extends GameState {
           Math.random() * -10 - 5
         );
         b.color = vec3.fromValues(Math.random(), Math.random(), Math.random());
-        b.desiredMotion.linearVelocity[1] = -0.03;
+        b.motion.linearVelocity[1] = -0.03;
         this.addObject(b);
         // TODO(@darzu): debug
         console.log(`box: ${b.id}`);
@@ -486,8 +486,8 @@ class CubeGameState extends GameState {
   spawnBullet(motion: MotionProps) {
     let bullet = new Bullet(this.newId(), this.me);
     copyMotionProps(bullet.motion, motion);
-    vec3.copy(bullet.desiredMotion.linearVelocity, motion.linearVelocity);
-    vec3.copy(bullet.desiredMotion.angularVelocity, motion.angularVelocity);
+    vec3.copy(bullet.motion.linearVelocity, motion.linearVelocity);
+    vec3.copy(bullet.motion.angularVelocity, motion.angularVelocity);
     this.addObjectInstance(bullet, this.bulletProto);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -412,7 +412,7 @@ class CubeGameState extends GameState {
         boat.motion.location[0] = (Math.random() - 0.5) * 20 - 10;
         boat.motion.location[2] = (Math.random() - 0.5) * 20 - 20;
         boat.boat.speed = 0.01 + jitter(0.01);
-        boat.boat.wheelDir = jitter(0.002);
+        boat.boat.wheelSpeed = jitter(0.002);
         this.addObject(boat);
       }
 

--- a/src/phys.ts
+++ b/src/phys.ts
@@ -13,7 +13,6 @@ import {
   createMotionProps,
   MotionProps,
   moveObjects,
-  VelocityProps,
 } from "./phys_motion.js";
 import { __isSMI } from "./util.js";
 import { vec3Dbg } from "./utils-3d.js";
@@ -29,7 +28,6 @@ export interface PhysicsObjectUninit {
 export interface PhysicsObject {
   id: number;
   motion: MotionProps;
-  desiredMotion: VelocityProps;
   lastMotion: MotionProps;
   localAABB: AABB;
   worldAABB: AABB;

--- a/src/phys_motion.ts
+++ b/src/phys_motion.ts
@@ -4,12 +4,9 @@ import { clamp } from "./math.js";
 import { CollidesWith, idPair, IdPair, ContactData, __step } from "./phys.js";
 import { AABB } from "./phys_broadphase.js";
 import { vec3Dbg } from "./utils-3d.js";
-
-export interface VelocityProps {
+export interface MotionProps {
   linearVelocity: vec3;
   angularVelocity: vec3;
-}
-export interface MotionProps extends VelocityProps {
   location: vec3;
   rotation: quat;
 }
@@ -59,7 +56,6 @@ const _constrainedVelocities = new Map<number, vec3>();
 export interface MotionObj {
   id: number;
   motion: MotionProps;
-  desiredMotion: VelocityProps;
   worldAABB: AABB;
 }
 
@@ -71,9 +67,9 @@ export function moveObjects(
 ) {
   const objs = Object.values(set);
 
-  // copy .desiredMotion to .motion; we want to try to meet the gameplay wants
+  // copy .motion to .motion; we want to try to meet the gameplay wants
   for (let o of objs) {
-    copyMotionProps(o.motion, o.desiredMotion);
+    copyMotionProps(o.motion, o.motion);
   }
 
   // TODO(@darzu): probably don't need this intermediate _constrainedVelocities

--- a/src/player.ts
+++ b/src/player.ts
@@ -3,11 +3,7 @@
 import { quat, vec3 } from "./gl-matrix.js";
 import { Inputs } from "./inputs.js";
 import { CameraProps } from "./main.js";
-import {
-  createMotionProps,
-  MotionProps,
-  VelocityProps,
-} from "./phys_motion.js";
+import { createMotionProps, MotionProps } from "./phys_motion.js";
 
 export interface PlayerProps {
   jumpSpeed: number;
@@ -25,7 +21,6 @@ export interface PlayerObj {
   id: number;
   player: PlayerProps;
   motion: MotionProps;
-  desiredMotion: VelocityProps;
 }
 
 export function stepPlayer(
@@ -36,7 +31,7 @@ export function stepPlayer(
   spawnBullet: (motion: MotionProps) => void
 ) {
   // fall with gravity
-  player.desiredMotion.linearVelocity[1] -= player.player.gravity * dt;
+  player.motion.linearVelocity[1] -= player.player.gravity * dt;
 
   // move player
   let vel = vec3.fromValues(0, 0, 0);
@@ -61,16 +56,16 @@ export function stepPlayer(
   //   vec3.add(vel, vel, vec3.fromValues(0, -n, 0));
   // }
   if (inputs.keyClicks[" "]) {
-    player.desiredMotion.linearVelocity[1] = player.player.jumpSpeed * dt;
+    player.motion.linearVelocity[1] = player.player.jumpSpeed * dt;
   }
 
   vec3.transformQuat(vel, vel, player.motion.rotation);
 
-  // vec3.add(player.desiredMotion.linearVelocity, player.desiredMotion.linearVelocity, vel);
+  // vec3.add(player.motion.linearVelocity, player.motion.linearVelocity, vel);
 
   // x and z from local movement
-  player.desiredMotion.linearVelocity[0] = vel[0];
-  player.desiredMotion.linearVelocity[2] = vel[2];
+  player.motion.linearVelocity[0] = vel[0];
+  player.motion.linearVelocity[2] = vel[2];
 
   quat.rotateY(
     player.motion.rotation,

--- a/src/state.ts
+++ b/src/state.ts
@@ -7,7 +7,6 @@ import {
   copyMotionProps,
   createMotionProps,
   MotionProps,
-  VelocityProps,
 } from "./phys_motion.js";
 import { CollidesWith, ReboundData, IdPair, stepPhysics } from "./phys.js";
 import { Inputs } from "./inputs.js";
@@ -60,7 +59,6 @@ export abstract class GameObject {
   // physics
   motion: MotionProps;
   lastMotion?: MotionProps;
-  desiredMotion: VelocityProps;
   localAABB: AABB;
   worldAABB: AABB;
   motionAABB: AABB;
@@ -73,10 +71,6 @@ export abstract class GameObject {
   constructor(id: number, creator: number) {
     this.id = id;
     this.creator = creator;
-    this.desiredMotion = {
-      linearVelocity: vec3.fromValues(0, 0, 0),
-      angularVelocity: vec3.fromValues(0, 0, 0),
-    };
     this.motion = createMotionProps({
       location: vec3.fromValues(0, 0, 0),
       rotation: quat.identity(quat.create()),


### PR DESCRIPTION
Here's a branch that removes desiredMotion vs motion separation.

It does have gameplay implications:
objects that collide with each other permanently have their velocities changed instead of just getting stuck until the object moves so it can resume its initial direction.

I'm not sure we want this change. It'd be good to test and discuss.

Notice the boats velocity no longer matches their rotation and the cubes slide permanently once they hit a wall:

https://user-images.githubusercontent.com/6453828/139472006-917a2bff-450c-4b53-9fa3-0f88dd57df4e.mov
