### PR TITLE
Improve query speed using caches

### DIFF
--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -216,11 +216,6 @@ export class EntityManager {
       const allNeededCs = this._systemsToComponents.get(name);
       if (allNeededCs?.every((n) => n in e)) {
         this._systemsToEntities.get(name)?.push(id);
-
-        // TODO(@darzu): DEBUGGING
-        if (name === "moveCubes") {
-          console.log(`adding ${id} to cache for ${name}`);
-        }
       }
     }
 
@@ -306,14 +301,7 @@ export class EntityManager {
       if (es) {
         const indx = es.findIndex((v) => v === id);
         if (indx > 0) es.splice(indx, 1);
-
-        // TODO(@darzu): DEBUGGING
-        // throw `Query cache in invalid state: ${id} w/ ${def.name} is missing from cache for ${name}`;
       }
-
-      // TODO(@darzu): DEBUGGING
-      if (def.name === "transform")
-        console.log(`removing ${def.name} from ${id}`);
     }
   }
 
@@ -453,14 +441,6 @@ export class EntityManager {
         cs.map((c) => c.name)
       );
     }
-
-    // TODO(@darzu): DEBUGGING
-    if (name === "moveCubes") {
-      console.log(`cached es: ${es.map((e) => e.id).join(",")}`);
-      for (let c of cs ?? []) {
-        console.log(`component: ${c.id}, ${c.name}`);
-      }
-    }
   }
 
   callSystems() {
@@ -474,23 +454,9 @@ export class EntityManager {
         es = this._systemsToEntities
           .get(s.name)!
           .map((id) => this.entities.get(id)! as EntityW<any[]>);
-      else es = this.filterEntities(s.cs);
-      if (!es || es.some((e) => !e)) {
-        throw `query cache corrupt: while calling ${s.name}! ${es
-          .map((e, i) => [e, i] as const)
-          .filter(([e, i]) => !e)
-          .map(([_, i]) => this._systemsToEntities.get(s.name)![i])
-          .join(",")} doesn't have ent`;
-      }
-      for (let e of es) {
-        const cs = s.cs as ComponentDef[] | null;
-        if (cs && !cs.every((c) => c.name in e)) {
-          throw `query cache corrupt: ${e.id} is in cache for ${
-            s.name
-          }, but is missing: ${cs
-            .filter((c) => !(c.name in e))
-            .map((c) => c.name)}`;
-        }
+      else {
+        throw `System ${s.name} doesn't have a query cache!`
+        // es = this.filterEntities(s.cs);
       }
 
       let haveAllResources = true;

--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -84,6 +84,10 @@ export class EntityManager {
   stats: Record<string, SystemStats> = {};
   loops: number = 0;
 
+  _systemsToEntities: Map<string, number[]> = new Map();
+  _systemsToComponents: Map<string, string[]> = new Map();
+  _componentToSystems: Map<string, string[]> = new Map();
+
   constructor() {
     this.entities.set(0, { id: 0 });
   }
@@ -205,6 +209,21 @@ export class EntityManager {
     if (def.name in e)
       throw `double defining component ${def.name} on ${e.id}!`;
     (e as any)[def.name] = c;
+
+    // update query caches
+    const systems = this._componentToSystems.get(def.name);
+    for (let name of systems ?? []) {
+      const allNeededCs = this._systemsToComponents.get(name);
+      if (allNeededCs?.every((n) => n in e)) {
+        this._systemsToEntities.get(name)?.push(id);
+
+        // TODO(@darzu): DEBUGGING
+        if (name === "moveCubes") {
+          console.log(`adding ${id} to cache for ${name}`);
+        }
+      }
+    }
+
     return c;
   }
 
@@ -224,13 +243,13 @@ export class EntityManager {
     def: ComponentDef<N, P, Pargs>,
     ...args: Pargs
   ): P {
-    this.checkComponent(def);
-    if (id === 0) throw `hey, use addSingletonComponent!`;
     const e = this.entities.get(id)!;
-    if (!(def.name in e)) {
-      (e as any)[def.name] = def.construct(...args);
+    const alreadyHas = def.name in e;
+    if (!alreadyHas) {
+      return this.addComponent(id, def, ...args);
+    } else {
+      return (e as any)[def.name];
     }
-    return (e as any)[def.name];
   }
 
   public addSingletonComponent<
@@ -279,6 +298,23 @@ export class EntityManager {
     } else {
       throw `Tried to remove absent component ${def.name} from entity ${id}`;
     }
+
+    // update query cache
+    const systems = this._componentToSystems.get(def.name);
+    for (let name of systems ?? []) {
+      const es = this._systemsToEntities.get(name);
+      if (es) {
+        const indx = es.findIndex((v) => v === id);
+        if (indx > 0) es.splice(indx, 1);
+
+        // TODO(@darzu): DEBUGGING
+        // throw `Query cache in invalid state: ${id} w/ ${def.name} is missing from cache for ${name}`;
+      }
+
+      // TODO(@darzu): DEBUGGING
+      if (def.name === "transform")
+        console.log(`removing ${def.name} from ${id}`);
+    }
   }
 
   public keepOnlyComponents<CS extends ComponentDef[]>(
@@ -289,7 +325,7 @@ export class EntityManager {
     if (!ent) throw `Tried to delete non-existent entity ${id}`;
     for (let component of this.components.values()) {
       if (!cs.includes(component) && ent[component.name]) {
-        delete ent[component.name];
+        this.removeComponent(id, component);
       }
     }
   }
@@ -396,13 +432,67 @@ export class EntityManager {
       name,
     });
     this.stats[name] = { calls: 0, queries: 0, callTime: 0, queryTime: 0 };
+
+    // update query cache:
+    //  pre-compute entities for this system for quicker queries; these caches will be maintained
+    //  by add/remove/ensure component calls
+    // TODO(@darzu): ability to toggle this optimization on/off for better debugging
+    const es = this.filterEntities(cs);
+    this._systemsToEntities.set(
+      name,
+      es.map((e) => e.id)
+    );
+    if (cs) {
+      for (let c of cs) {
+        if (!this._componentToSystems.has(c.name))
+          this._componentToSystems.set(c.name, [name]);
+        else this._componentToSystems.get(c.name)!.push(name);
+      }
+      this._systemsToComponents.set(
+        name,
+        cs.map((c) => c.name)
+      );
+    }
+
+    // TODO(@darzu): DEBUGGING
+    if (name === "moveCubes") {
+      console.log(`cached es: ${es.map((e) => e.id).join(",")}`);
+      for (let c of cs ?? []) {
+        console.log(`component: ${c.id}, ${c.name}`);
+      }
+    }
   }
 
   callSystems() {
     // dispatch to all the systems
     for (let s of this.systems) {
       let start = performance.now();
-      const es = this.filterEntities(s.cs);
+
+      // try looking up in the query cache
+      let es: Entities<any[]>;
+      if (this._systemsToEntities.has(s.name))
+        es = this._systemsToEntities
+          .get(s.name)!
+          .map((id) => this.entities.get(id)! as EntityW<any[]>);
+      else es = this.filterEntities(s.cs);
+      if (!es || es.some((e) => !e)) {
+        throw `query cache corrupt: while calling ${s.name}! ${es
+          .map((e, i) => [e, i] as const)
+          .filter(([e, i]) => !e)
+          .map(([_, i]) => this._systemsToEntities.get(s.name)![i])
+          .join(",")} doesn't have ent`;
+      }
+      for (let e of es) {
+        const cs = s.cs as ComponentDef[] | null;
+        if (cs && !cs.every((c) => c.name in e)) {
+          throw `query cache corrupt: ${e.id} is in cache for ${
+            s.name
+          }, but is missing: ${cs
+            .filter((c) => !(c.name in e))
+            .map((c) => c.name)}`;
+        }
+      }
+
       let haveAllResources = true;
       for (let r of s.rs) {
         // note this is just to verify it exists


### PR DESCRIPTION
With ~1000 entities

Before:
<img width="644" alt="Screen Shot 2021-12-10 at 11 06 48 AM" src="https://user-images.githubusercontent.com/6453828/145613426-4b25ef97-e9fb-44ed-b11f-af914168862d.png">

After:
<img width="384" alt="Screen Shot 2021-12-10 at 11 04 44 AM" src="https://user-images.githubusercontent.com/6453828/145613433-d26bdcc8-ef0a-4aee-a0fa-13c2c745b622.png">

This just uses a few simple hash maps that are updated by: 
registerSystem, addComponent, and removeComponent
the hash maps are:
```typescript
_systemsToEntities: Map<string, number[]>
_systemsToComponents: Map<string, string[]>
_componentToSystems: Map<string, string[]>
```

This does make adding and remove components slower. I didn't notice any slow down when firing large bullet spreads, but some more rigorous analysis would probably be good.