### PR TITLE
Fix bug where camera smoothing takes the long way around

### DIFF
--- a/src/smoothing.ts
+++ b/src/smoothing.ts
@@ -3,6 +3,7 @@ import { tempQuat } from "./temp-pool.js";
 
 const ERROR_SMOOTHING_FACTOR = 0.9 ** (60 / 1000);
 const EPSILON = 0.0001;
+const QUAT_EPSILON = 0.001;
 
 const identityQuat: ReadonlyQuat = quat.identity(quat.create());
 
@@ -24,10 +25,12 @@ export function reduceError(
     }
   } else {
     const magnitude = Math.abs(quat.getAngle(v, identityQuat));
-    if (magnitude > EPSILON) {
+    if (magnitude > QUAT_EPSILON) {
+      console.log("mag > EPSILON");
       quat.slerp(v, v, identityQuat, 1 - smoothing_factor ** dt);
       quat.normalize(v, v);
     } else if (magnitude > 0) {
+      console.log("normalizing");
       quat.copy(v, identityQuat);
     }
   }

--- a/src/smoothing.ts
+++ b/src/smoothing.ts
@@ -26,11 +26,9 @@ export function reduceError(
   } else {
     const magnitude = Math.abs(quat.getAngle(v, identityQuat));
     if (magnitude > QUAT_EPSILON) {
-      console.log("mag > EPSILON");
       quat.slerp(v, v, identityQuat, 1 - smoothing_factor ** dt);
       quat.normalize(v, v);
     } else if (magnitude > 0) {
-      console.log("normalizing");
       quat.copy(v, identityQuat);
     }
   }


### PR DESCRIPTION
We can smooth the target rotation and rotation together, which
prevents cases where the offset rotation and target rotation deltas
added up to > PI (causing us to go the long way around an object).