### PR TITLE
Fix code for changed textureDimensions type

### DIFF
--- a/public/shaders/std-blur.wgsl
+++ b/public/shaders/std-blur.wgsl
@@ -14,7 +14,7 @@ fn main(
   let blockDim = tileDim - (filterDim - 1u);
 
   let filterOffset : u32 = (filterDim - 1u) / 2u;
-  let dims : vec2<i32> = textureDimensions(inTex, 0);
+  let dims : vec2<i32> = vec2<i32>(textureDimensions(inTex, 0));
 
   let baseIndex = vec2<i32>(
     WorkGroupID.xy * vec2<u32>(blockDim, 4u) +

--- a/public/shaders/std-jump-flood.wgsl
+++ b/public/shaders/std-jump-flood.wgsl
@@ -6,7 +6,7 @@
 
  @fragment
 fn frag_main(@location(0) centerUV : vec2<f32>) -> @location(0) vec2<f32> {
-  let dimsI : vec2<i32> = textureDimensions(inTex);
+  let dimsI : vec2<i32> = vec2<i32>(textureDimensions(inTex));
   let dimsF = vec2<f32>(dimsI);
   let centerXY = vec2<i32>(centerUV * dimsF);
 

--- a/public/shaders/std-outline.wgsl
+++ b/public/shaders/std-outline.wgsl
@@ -36,7 +36,7 @@ fn frag_main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
   // TODO(@darzu): it'd be great if we could just output lines and compose elsewhere
   var color = textureSample(colorTex, samp, uv).rgb;
 
-  let dims : vec2<i32> = textureDimensions(surfTex);
+  let dims : vec2<u32> = textureDimensions(surfTex);
   let dimsF = vec2<f32>(dims);
 
   let lineWidth = 2.0;

--- a/public/shaders/xp-cloth-update.wgsl
+++ b/public/shaders/xp-cloth-update.wgsl
@@ -6,7 +6,7 @@
 fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   // var index : u32 = GlobalInvocationID.x;
 
-  // let dims : vec2<i32> = textureDimensions(inTex, 0);
+  // let dims : vec2<u32> = textureDimensions(inTex, 0);
 
   // let uv: vec2<f32> = vec2<f32>(0.5, 0.5);
 

--- a/src/render/gpu-helper.ts
+++ b/src/render/gpu-helper.ts
@@ -132,7 +132,7 @@ export function createRenderTextureToQuad(
 
     @fragment
     fn frag_main(@location(0) uv : vec2<f32>) -> @location(0) ${returnWgslType} {
-      let dimsI : vec2<i32> = textureDimensions(inTex);
+      let dimsI : vec2<u32> = textureDimensions(inTex);
       let dimsF = vec2<f32>(dimsI);
       let xy = vec2<i32>(uv * dimsF);
       ${


### PR DESCRIPTION
It now returns a `vec2<i32>`. I had to do this in order to get sprig to run on the latest Chrome Canary.