### PR TITLE
UpdatableComponentDef, NonupdatableComponentDef, and "ensureComponentOn" -> "set"

### DIFF
--- a/src/animation/animate-to.ts
+++ b/src/animation/animate-to.ts
@@ -18,7 +18,7 @@ export interface AnimateTo {
   // TODO(@darzu): pathFn
 }
 
-export const AnimateToDef = EM.defineComponent2(
+export const AnimateToDef = EM.defineComponent(
   "animateTo",
   function (): AnimateTo {
     return {

--- a/src/animation/animate-to.ts
+++ b/src/animation/animate-to.ts
@@ -18,16 +18,19 @@ export interface AnimateTo {
   // TODO(@darzu): pathFn
 }
 
-export const AnimateToDef = EM.defineComponent(
+export const AnimateToDef = EM.defineComponent2(
   "animateTo",
-  function (a?: Partial<AnimateTo>): AnimateTo {
+  function (): AnimateTo {
     return {
-      startPos: a?.startPos ?? vec3.create(),
-      endPos: a?.endPos ?? vec3.create(),
-      easeFn: a?.easeFn ?? EASE_LINEAR,
-      durationMs: a?.durationMs ?? 1000,
-      progressMs: a?.progressMs ?? 0,
+      startPos: vec3.create(),
+      endPos: vec3.create(),
+      easeFn: EASE_LINEAR,
+      durationMs: 1000,
+      progressMs: 0,
     };
+  },
+  function (p, a?: Partial<AnimateTo>): AnimateTo {
+    return a ? Object.assign(p, a) : p;
   }
 );
 

--- a/src/animation/animate-to.ts
+++ b/src/animation/animate-to.ts
@@ -18,19 +18,16 @@ export interface AnimateTo {
   // TODO(@darzu): pathFn
 }
 
-export const AnimateToDef = EM.defineComponent(
+export const AnimateToDef = EM.defineNonupdatableComponent(
   "animateTo",
-  function (): AnimateTo {
+  function (a?: Partial<AnimateTo>): AnimateTo {
     return {
-      startPos: vec3.create(),
-      endPos: vec3.create(),
-      easeFn: EASE_LINEAR,
-      durationMs: 1000,
-      progressMs: 0,
+      startPos: a?.startPos ?? vec3.create(),
+      endPos: a?.endPos ?? vec3.create(),
+      easeFn: a?.easeFn ?? EASE_LINEAR,
+      durationMs: a?.durationMs ?? 1000,
+      progressMs: a?.progressMs ?? 0,
     };
-  },
-  function (p, a?: Partial<AnimateTo>): AnimateTo {
-    return a ? Object.assign(p, a) : p;
   }
 );
 

--- a/src/animation/noodles.ts
+++ b/src/animation/noodles.ts
@@ -24,15 +24,11 @@ export interface NoodleSeg {
   dir: vec3;
 }
 
-export const NoodleDef = EM.defineComponent(
+export const NoodleDef = EM.defineNonupdatableComponent(
   "noodle",
-  () => ({
-    segments: [] as NoodleSeg[],
-  }),
-  (p, segments: NoodleSeg[]) => {
-    p.segments.push(...segments);
-    return p;
-  }
+  (segments: NoodleSeg[]) => ({
+    segments,
+  })
 );
 export type Noodle = Component<typeof NoodleDef>;
 

--- a/src/animation/noodles.ts
+++ b/src/animation/noodles.ts
@@ -51,12 +51,12 @@ export function debugCreateNoodles() {
 
   // TODO(@darzu): test cube faces (update: they are correct)
   // const cube = EM.newEntity();
-  // EM.ensureComponentOn(cube, PositionDef, [0, -2, 0]);
+  // EM.set(cube, PositionDef, [0, -2, 0]);
   // const cubeM = cloneMesh(CUBE_MESH);
   // for (let triIdx of CUBE_FACES.bottom) {
   //   cubeM.colors[triIdx] = [0, 0, 0.5];
   // }
-  // EM.ensureComponentOn(cube, RenderableConstructDef, cubeM);
+  // EM.set(cube, RenderableConstructDef, cubeM);
 }
 
 export function registerNoodleSystem() {

--- a/src/animation/noodles.ts
+++ b/src/animation/noodles.ts
@@ -24,11 +24,15 @@ export interface NoodleSeg {
   dir: vec3;
 }
 
-export const NoodleDef = EM.defineComponent(
+export const NoodleDef = EM.defineComponent2(
   "noodle",
-  (segments: NoodleSeg[]) => ({
-    segments,
-  })
+  () => ({
+    segments: [] as NoodleSeg[],
+  }),
+  (p, segments: NoodleSeg[]) => {
+    p.segments.push(...segments);
+    return p;
+  }
 );
 export type Noodle = Component<typeof NoodleDef>;
 

--- a/src/animation/noodles.ts
+++ b/src/animation/noodles.ts
@@ -35,7 +35,7 @@ export type Noodle = Component<typeof NoodleDef>;
 // TODO(@darzu): DEBUGGING
 export function debugCreateNoodles() {
   const e = EM.new();
-  EM.ensureComponentOn(e, NoodleDef, [
+  EM.set(e, NoodleDef, [
     {
       pos: V(0, 0, 0),
       dir: V(0, -1, 0),
@@ -46,8 +46,8 @@ export function debugCreateNoodles() {
     },
   ]);
   const m = createNoodleMesh(0.1, V(0.2, 0.05, 0.05));
-  EM.ensureComponentOn(e, RenderableConstructDef, m);
-  EM.ensureComponentOn(e, PositionDef, V(5, -5, 0));
+  EM.set(e, RenderableConstructDef, m);
+  EM.set(e, PositionDef, V(5, -5, 0));
 
   // TODO(@darzu): test cube faces (update: they are correct)
   // const cube = EM.newEntity();

--- a/src/animation/noodles.ts
+++ b/src/animation/noodles.ts
@@ -24,7 +24,7 @@ export interface NoodleSeg {
   dir: vec3;
 }
 
-export const NoodleDef = EM.defineComponent2(
+export const NoodleDef = EM.defineComponent(
   "noodle",
   () => ({
     segments: [] as NoodleSeg[],

--- a/src/animation/skeletal.ts
+++ b/src/animation/skeletal.ts
@@ -13,12 +13,19 @@ interface QueuedAnimation {
   t: number;
 }
 
-export const PoseDef = EM.defineComponent("pose", (current?: number) => ({
-  t: 0,
-  current: current || 0,
-  queue: [] as QueuedAnimation[],
-  repeat: [] as QueuedAnimation[],
-}));
+export const PoseDef = EM.defineComponent2(
+  "pose",
+  () => ({
+    t: 0,
+    current: 0,
+    queue: [] as QueuedAnimation[],
+    repeat: [] as QueuedAnimation[],
+  }),
+  (p, current?: number) => {
+    p.current = current ?? 0;
+    return p;
+  }
+);
 
 EM.addEagerInit([PoseDef], [], [], () => {
   EM.addSystem(

--- a/src/animation/skeletal.ts
+++ b/src/animation/skeletal.ts
@@ -13,18 +13,14 @@ interface QueuedAnimation {
   t: number;
 }
 
-export const PoseDef = EM.defineComponent(
+export const PoseDef = EM.defineNonupdatableComponent(
   "pose",
-  () => ({
+  (current?: number) => ({
     t: 0,
-    current: 0,
+    current: current || 0,
     queue: [] as QueuedAnimation[],
     repeat: [] as QueuedAnimation[],
-  }),
-  (p, current?: number) => {
-    p.current = current ?? 0;
-    return p;
-  }
+  })
 );
 
 EM.addEagerInit([PoseDef], [], [], () => {

--- a/src/animation/skeletal.ts
+++ b/src/animation/skeletal.ts
@@ -13,7 +13,7 @@ interface QueuedAnimation {
   t: number;
 }
 
-export const PoseDef = EM.defineComponent2(
+export const PoseDef = EM.defineComponent(
   "pose",
   () => ({
     t: 0,

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -66,14 +66,18 @@ export const CameraComputedDef = EM.defineResource("cameraComputed", () => {
 });
 export type CameraView = Resource<typeof CameraComputedDef>;
 
-export const CameraFollowDef = EM.defineComponent(
+export const CameraFollowDef = EM.defineComponent2(
   "cameraFollow",
-  (priority = 0) => ({
+  () => ({
     positionOffset: vec3.create(),
     yawOffset: 0,
     pitchOffset: 0,
-    priority,
-  })
+    priority: 0,
+  }),
+  (p, priority = 0) => {
+    p.priority = priority;
+    return p;
+  }
 );
 
 export const CAMERA_OFFSETS = {

--- a/src/camera/camera.ts
+++ b/src/camera/camera.ts
@@ -66,7 +66,7 @@ export const CameraComputedDef = EM.defineResource("cameraComputed", () => {
 });
 export type CameraView = Resource<typeof CameraComputedDef>;
 
-export const CameraFollowDef = EM.defineComponent2(
+export const CameraFollowDef = EM.defineComponent(
   "cameraFollow",
   () => ({
     positionOffset: vec3.create(),

--- a/src/cannons/bullet-collision.ts
+++ b/src/cannons/bullet-collision.ts
@@ -4,7 +4,7 @@ import {
   DetectedEventsDef,
   eventWizard,
 } from "../net/events.js";
-import { EDef, EM, Entity, ESet } from "../ecs/entity-manager.js";
+import { ComponentDef, EDef, EM, Entity, ESet } from "../ecs/entity-manager.js";
 import { HsPlayerDef } from "../hyperspace/hs-player.js";
 import { PhysicsResultsDef } from "../physics/nonintersection.js";
 import { AuthorityDef } from "../net/components.js";

--- a/src/cannons/bullet-collision.ts
+++ b/src/cannons/bullet-collision.ts
@@ -4,7 +4,7 @@ import {
   DetectedEventsDef,
   eventWizard,
 } from "../net/events.js";
-import { ComponentDef, EDef, EM, Entity, ESet } from "../ecs/entity-manager.js";
+import { EDef, EM, Entity, ESet } from "../ecs/entity-manager.js";
 import { HsPlayerDef } from "../hyperspace/hs-player.js";
 import { PhysicsResultsDef } from "../physics/nonintersection.js";
 import { AuthorityDef } from "../net/components.js";

--- a/src/cannons/bullet-collision.ts
+++ b/src/cannons/bullet-collision.ts
@@ -65,8 +65,8 @@ export const raiseBulletBullet = eventWizard(
   ([b1, b2]) => {
     // assert(false, `raiseBulletBullet doesnt work on ld51`); // TODO(@darzu): ld51
     // This bullet might have already been deleted via the sync system
-    EM.ensureComponentOn(b1, DeletedDef);
-    EM.ensureComponentOn(b2, DeletedDef);
+    EM.set(b1, DeletedDef);
+    EM.set(b2, DeletedDef);
   },
   {
     // The authority entity is the one with the lowest id
@@ -79,7 +79,7 @@ export const raiseBulletPlayer = eventWizard(
   () => [[BulletDef], [HsPlayerDef]] as const,
   ([bullet, player]) => {
     // assert(false, `raiseBulletPlayer doesnt work on ld51`); // TODO(@darzu): ld51
-    EM.ensureComponent(bullet.id, DeletedDef);
+    EM.set(bullet, DeletedDef);
   }
 );
 
@@ -88,7 +88,7 @@ export const raiseBulletEnemyShip = eventWizard(
   () => [[BulletDef], [EnemyShipLocalDef, PositionDef, RotationDef]] as const,
   ([bullet, enemyShip]) => {
     // assert(false, `raiseBulletEnemyShip doesnt work on ld51`); // TODO(@darzu): ld51
-    EM.ensureComponentOn(bullet, DeletedDef);
+    EM.set(bullet, DeletedDef);
     const res = EM.getResources([AllMeshesDef, AudioDef])!;
     breakEnemyShip(enemyShip, res.allMeshes.boat_broken, res.music);
   }

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -57,9 +57,20 @@ export const BulletDef = EM.defineComponent2(
 );
 export type Bullet = Component<typeof BulletDef>;
 
-export const BulletConstructDef = EM.defineComponent(
+export const BulletConstructDef = EM.defineComponent2(
   "bulletConstruct",
+  () => {
+    return {
+      location: V(0, 0, 0),
+      linearVelocity: V(0, 1, 0),
+      angularVelocity: V(0, 0, 0),
+      team: 0,
+      gravity: 0,
+      health: 0,
+    };
+  },
   (
+    p,
     loc?: vec3,
     vel?: vec3,
     angVel?: vec3,
@@ -67,14 +78,13 @@ export const BulletConstructDef = EM.defineComponent(
     gravity?: number,
     health?: number
   ) => {
-    return {
-      location: loc ?? V(0, 0, 0),
-      linearVelocity: vel ?? V(0, 1, 0),
-      angularVelocity: angVel ?? V(0, 0, 0),
-      team: team ?? 0,
-      gravity: gravity ?? 0,
-      health: health ?? 0,
-    };
+    if (loc) vec3.copy(p.location, loc);
+    if (vel) vec3.copy(p.linearVelocity, vel);
+    if (angVel) vec3.copy(p.angularVelocity, angVel);
+    if (team) p.team = team;
+    if (gravity) p.gravity = gravity;
+    if (health) p.health = health;
+    return p;
   }
 );
 export type BulletConstruct = Component<typeof BulletConstructDef>;

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -111,14 +111,14 @@ export function createOrResetBullet(
 ) {
   const props = e.bulletConstruct;
   assertDbg(props);
-  EM.ensureComponentOn(e, PositionDef);
+  EM.set(e, PositionDef);
   vec3.copy(e.position, props.location);
-  EM.ensureComponentOn(e, RotationDef);
+  EM.set(e, RotationDef);
   // EM.ensureComponentOn(e, LinearVelocityDef);
   // vec3.copy(e.linearVelocity, props.linearVelocity);
-  EM.ensureComponentOn(e, AngularVelocityDef);
+  EM.set(e, AngularVelocityDef);
   vec3.copy(e.angularVelocity, props.angularVelocity);
-  EM.ensureComponentOn(e, ColorDef);
+  EM.set(e, ColorDef);
   if (props.team === 1) {
     vec3.copy(e.color, ENDESGA16.deepGreen);
   } else if (props.team === 2) {
@@ -126,28 +126,28 @@ export function createOrResetBullet(
   } else {
     vec3.copy(e.color, ENDESGA16.orange);
   }
-  EM.ensureComponentOn(e, MotionSmoothingDef);
-  EM.ensureComponentOn(e, RenderableConstructDef, res.allMeshes.ball.proto);
-  EM.ensureComponentOn(e, AuthorityDef, res.me.pid);
-  EM.ensureComponentOn(e, BulletDef);
+  EM.set(e, MotionSmoothingDef);
+  EM.set(e, RenderableConstructDef, res.allMeshes.ball.proto);
+  EM.set(e, AuthorityDef, res.me.pid);
+  EM.set(e, BulletDef);
   e.bullet.team = props.team;
   e.bullet.health = props.health;
-  EM.ensureComponentOn(e, ColliderDef, {
+  EM.set(e, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.ball.aabb,
   });
-  EM.ensureComponentOn(e, LifetimeDef);
+  EM.set(e, LifetimeDef);
   e.lifetime.ms = 8000;
-  EM.ensureComponentOn(e, SyncDef);
+  EM.set(e, SyncDef);
   e.sync.dynamicComponents = [PositionDef.id];
   e.sync.fullComponents = [BulletConstructDef.id];
-  EM.ensureComponentOn(e, PredictDef);
+  EM.set(e, PredictDef);
   // EM.ensureComponentOn(e, GravityDef);
   // e.gravity[1] = -props.gravity;
 
   // TODO(@darzu): MULTIPLAYER: fix sync & predict to work with parametric motion
-  EM.ensureComponentOn(e, ParametricDef);
+  EM.set(e, ParametricDef);
   vec3.copy(e.parametric.init.pos, props.location);
   vec3.copy(e.parametric.init.vel, props.linearVelocity);
   vec3.copy(e.parametric.init.accel, [0, -props.gravity, 0]);
@@ -214,7 +214,7 @@ export async function fireBullet(
   let e: BulletEnt;
   if (_bulletPool.length < _maxBullets) {
     let e_ = EM.new();
-    EM.ensureComponentOn(e_, BulletConstructDef);
+    EM.set(e_, BulletConstructDef);
     e = e_;
     _bulletPool.push(e);
   } else {
@@ -276,15 +276,15 @@ async function initBulletPartPool() {
     let bset: BulletPart[] = [];
     for (let part of allMeshes.ball_broken) {
       const pe = EM.new();
-      EM.ensureComponentOn(pe, RenderableConstructDef, part.proto);
-      EM.ensureComponentOn(pe, ColorDef);
-      EM.ensureComponentOn(pe, RotationDef);
-      EM.ensureComponentOn(pe, PositionDef);
-      EM.ensureComponentOn(pe, LinearVelocityDef);
-      EM.ensureComponentOn(pe, AngularVelocityDef);
+      EM.set(pe, RenderableConstructDef, part.proto);
+      EM.set(pe, ColorDef);
+      EM.set(pe, RotationDef);
+      EM.set(pe, PositionDef);
+      EM.set(pe, LinearVelocityDef);
+      EM.set(pe, AngularVelocityDef);
       // EM.ensureComponentOn(pe, LifetimeDef, 2000);
-      EM.ensureComponentOn(pe, GravityDef, V(0, -4 * 0.00001, 0));
-      EM.ensureComponentOn(pe, SplinterParticleDef);
+      EM.set(pe, GravityDef, V(0, -4 * 0.00001, 0));
+      EM.set(pe, SplinterParticleDef);
       bset.push(pe);
     }
     bulletPartPool.push(bset);
@@ -325,16 +325,16 @@ export async function breakBullet(
     vec3.add(vel, [0, +1, 0], vel);
     vec3.normalize(vel, vel);
     vec3.scale(vel, 0.02, vel);
-    EM.ensureComponentOn(pe, LinearVelocityDef);
+    EM.set(pe, LinearVelocityDef);
     vec3.copy(pe.linearVelocity, vel);
-    EM.ensureComponentOn(pe, AngularVelocityDef);
+    EM.set(pe, AngularVelocityDef);
     vec3.copy(pe.angularVelocity, vel);
     // EM.ensureComponentOn(pe, LifetimeDef, 2000);
-    EM.ensureComponentOn(pe, GravityDef);
+    EM.set(pe, GravityDef);
     vec3.copy(pe.gravity, [0, -4 * 0.00001, 0]);
   }
 
-  EM.ensureComponentOn(bullet, DeadDef);
+  EM.set(bullet, DeadDef);
 }
 
 // TODO(@darzu): simulateBullet shouldn't be needed any more since we use

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -81,9 +81,9 @@ export const BulletConstructDef = EM.defineComponent(
     if (loc) vec3.copy(p.location, loc);
     if (vel) vec3.copy(p.linearVelocity, vel);
     if (angVel) vec3.copy(p.angularVelocity, angVel);
-    if (team) p.team = team;
-    if (gravity) p.gravity = gravity;
-    if (health) p.health = health;
+    if (team !== undefined) p.team = team;
+    if (gravity !== undefined) p.gravity = gravity;
+    if (health !== undefined) p.health = health;
     return p;
   }
 );

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -111,47 +111,45 @@ export function createOrResetBullet(
 ) {
   const props = e.bulletConstruct;
   assertDbg(props);
-  EM.set(e, PositionDef);
-  vec3.copy(e.position, props.location);
+  EM.set(e, PositionDef, props.location);
   EM.set(e, RotationDef);
-  // EM.ensureComponentOn(e, LinearVelocityDef);
+  // EM.set(e, LinearVelocityDef);
   // vec3.copy(e.linearVelocity, props.linearVelocity);
-  EM.set(e, AngularVelocityDef);
-  vec3.copy(e.angularVelocity, props.angularVelocity);
-  EM.set(e, ColorDef);
+  EM.set(e, AngularVelocityDef, props.angularVelocity);
   if (props.team === 1) {
-    vec3.copy(e.color, ENDESGA16.deepGreen);
+    EM.set(e, ColorDef, ENDESGA16.deepGreen);
   } else if (props.team === 2) {
-    vec3.copy(e.color, ENDESGA16.deepBrown);
+    EM.set(e, ColorDef, ENDESGA16.deepBrown);
   } else {
-    vec3.copy(e.color, ENDESGA16.orange);
+    EM.set(e, ColorDef, ENDESGA16.orange);
   }
   EM.set(e, MotionSmoothingDef);
   EM.set(e, RenderableConstructDef, res.allMeshes.ball.proto);
   EM.set(e, AuthorityDef, res.me.pid);
-  EM.set(e, BulletDef);
-  e.bullet.team = props.team;
-  e.bullet.health = props.health;
+  EM.set(e, BulletDef, props.team, props.health);
   EM.set(e, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.ball.aabb,
   });
-  EM.set(e, LifetimeDef);
-  e.lifetime.ms = 8000;
-  EM.set(e, SyncDef);
-  e.sync.dynamicComponents = [PositionDef.id];
+  EM.set(e, LifetimeDef, 8000);
+  EM.set(e, SyncDef, [PositionDef.id]);
   e.sync.fullComponents = [BulletConstructDef.id];
   EM.set(e, PredictDef);
-  // EM.ensureComponentOn(e, GravityDef);
+  // EM.set(e, GravityDef);
   // e.gravity[1] = -props.gravity;
 
   // TODO(@darzu): MULTIPLAYER: fix sync & predict to work with parametric motion
-  EM.set(e, ParametricDef);
-  vec3.copy(e.parametric.init.pos, props.location);
-  vec3.copy(e.parametric.init.vel, props.linearVelocity);
-  vec3.copy(e.parametric.init.accel, [0, -props.gravity, 0]);
-  e.parametric.startMs = res.time.time;
+  EM.set(
+    e,
+    ParametricDef,
+    {
+      pos: props.location,
+      vel: props.linearVelocity,
+      accel: [0, -props.gravity, 0],
+    },
+    res.time.time
+  );
   return e;
 }
 
@@ -165,7 +163,7 @@ export function registerBuildBulletsSystem() {
       for (let b of bullets) {
         // if (FinishedDef.isOn(b)) continue;
         // createOrUpdateBullet( b, res.me.pid, res.allMeshes);
-        // EM.ensureComponentOn(b, FinishedDef);
+        // EM.set(b, FinishedDef);
       }
     }
   );
@@ -282,7 +280,7 @@ async function initBulletPartPool() {
       EM.set(pe, PositionDef);
       EM.set(pe, LinearVelocityDef);
       EM.set(pe, AngularVelocityDef);
-      // EM.ensureComponentOn(pe, LifetimeDef, 2000);
+      // EM.set(pe, LifetimeDef, 2000);
       EM.set(pe, GravityDef, V(0, -4 * 0.00001, 0));
       EM.set(pe, SplinterParticleDef);
       bset.push(pe);
@@ -329,7 +327,7 @@ export async function breakBullet(
     vec3.copy(pe.linearVelocity, vel);
     EM.set(pe, AngularVelocityDef);
     vec3.copy(pe.angularVelocity, vel);
-    // EM.ensureComponentOn(pe, LifetimeDef, 2000);
+    // EM.set(pe, LifetimeDef, 2000);
     EM.set(pe, GravityDef);
     vec3.copy(pe.gravity, [0, -4 * 0.00001, 0]);
   }

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -41,13 +41,18 @@ import { SplinterParticleDef } from "../wood/wood-splinters.js";
 
 const _maxBullets = 100;
 
-export const BulletDef = EM.defineComponent(
+export const BulletDef = EM.defineComponent2(
   "bullet",
-  (team: number = 0, health: number = 10) => {
+  () => {
     return {
-      team,
-      health,
+      team: 0,
+      health: 10,
     };
+  },
+  (p, team: number = 0, health: number = 10) => {
+    p.team = team;
+    p.health = health;
+    return p;
   }
 );
 export type Bullet = Component<typeof BulletDef>;

--- a/src/cannons/bullet.ts
+++ b/src/cannons/bullet.ts
@@ -41,7 +41,7 @@ import { SplinterParticleDef } from "../wood/wood-splinters.js";
 
 const _maxBullets = 100;
 
-export const BulletDef = EM.defineComponent2(
+export const BulletDef = EM.defineComponent(
   "bullet",
   () => {
     return {
@@ -57,7 +57,7 @@ export const BulletDef = EM.defineComponent2(
 );
 export type Bullet = Component<typeof BulletDef>;
 
-export const BulletConstructDef = EM.defineComponent2(
+export const BulletConstructDef = EM.defineComponent(
   "bulletConstruct",
   () => {
     return {

--- a/src/cannons/cannon.ts
+++ b/src/cannons/cannon.ts
@@ -40,9 +40,9 @@ export const { CannonPropsDef, CannonLocalDef, createCannon, createCannonNow } =
       parentId?: number
     ) => {
       if (location) vec3.copy(p.location, location);
-      if (yaw) p.yaw = yaw;
-      if (pitch) p.pitch = pitch;
-      if (parentId) p.parentId = parentId;
+      if (yaw !== undefined) p.yaw = yaw;
+      if (pitch !== undefined) p.pitch = pitch;
+      if (parentId !== undefined) p.parentId = parentId;
       return p;
     },
     serializeProps: (c, buf) => {

--- a/src/cannons/cannon.ts
+++ b/src/cannons/cannon.ts
@@ -69,7 +69,7 @@ export const { CannonPropsDef, CannonLocalDef, createCannon, createCannonNow } =
     buildResources: [CannonLD51Mesh.def, MeDef],
     build: (e, res) => {
       const props = e.cannonProps;
-      EM.ensureComponentOn(e, PositionDef, props.location);
+      EM.set(e, PositionDef, props.location);
       constructNetTurret(
         e,
         props.yaw,
@@ -84,18 +84,18 @@ export const { CannonPropsDef, CannonLocalDef, createCannon, createCannonNow } =
         Math.PI / 4,
         "W/S: pitch, A/D: turn, left click: fire, E: drop cannon"
       );
-      EM.ensureComponentOn(e, ColorDef, V(0, 0, 0));
-      EM.ensureComponentOn(
+      EM.set(e, ColorDef, V(0, 0, 0));
+      EM.set(
         e,
         RenderableConstructDef,
         res.mesh_ld51_cannon.mesh // TODO(@darzu): PERF: use .proto?
       );
-      EM.ensureComponentOn(e, ColliderDef, {
+      EM.set(e, ColliderDef, {
         shape: "AABB",
         solid: false,
         aabb: res.mesh_ld51_cannon.aabb,
       });
-      EM.ensureComponentOn(e, PhysicsParentDef, props.parentId);
+      EM.set(e, PhysicsParentDef, props.parentId);
       return e;
     },
   });

--- a/src/cannons/cannon.ts
+++ b/src/cannons/cannon.ts
@@ -24,27 +24,37 @@ import { vec3Dbg } from "../utils/utils-3d.js";
 export const { CannonPropsDef, CannonLocalDef, createCannon, createCannonNow } =
   defineNetEntityHelper({
     name: "cannon",
-    defaultProps: (
-      loc?: vec3,
+    defaultProps: () => {
+      return {
+        location: V(0, 0, 0),
+        yaw: 0,
+        pitch: 0,
+        parentId: 0,
+      };
+    },
+    updateProps: (
+      p,
+      location?: vec3,
       yaw?: number,
       pitch?: number,
       parentId?: number
     ) => {
-      return {
-        location: loc ?? V(0, 0, 0),
-        yaw: yaw ?? 0,
-        pitch: pitch ?? 0,
-        parentId: parentId ?? 0,
-      };
+      if (location) vec3.copy(p.location, location);
+      if (yaw) p.yaw = yaw;
+      if (pitch) p.pitch = pitch;
+      if (parentId) p.parentId = parentId;
+      return p;
     },
     serializeProps: (c, buf) => {
       buf.writeVec3(c.location);
       buf.writeFloat32(c.yaw);
+      buf.writeFloat32(c.pitch);
       buf.writeUint32(c.parentId);
     },
     deserializeProps: (c, buf) => {
       buf.readVec3(c.location);
       c.yaw = buf.readFloat32();
+      c.pitch = buf.readFloat32();
       c.parentId = buf.readUint32();
     },
     defaultLocal: () => {

--- a/src/cloth/cloth.ts
+++ b/src/cloth/cloth.ts
@@ -28,22 +28,29 @@ export interface ClothConstruct {
   columns: number;
   distance: number;
 }
-export const ClothConstructDef = EM.defineComponent(
+export const ClothConstructDef = EM.defineComponent2(
   "clothConstruct",
-  (c: Partial<ClothConstruct>) => ({
-    location: c.location ?? V(0, 0, 0),
-    color: c.color ?? V(0, 0, 0),
-    rows: c.rows ?? 2,
-    columns: c.columns ?? 2,
-    distance: c.distance ?? 1,
-  })
+  () => ({
+    location: V(0, 0, 0),
+    color: V(0, 0, 0),
+    rows: 2,
+    columns: 2,
+    distance: 1,
+  }),
+  (p, c: Partial<ClothConstruct>) => {
+    return Object.assign(p, c);
+  }
 );
 
-export const ClothLocalDef = EM.defineComponent(
+export const ClothLocalDef = EM.defineComponent2(
   "clothLocal",
-  (posMap?: Map<number, number>) => ({
-    posMap: posMap ?? new Map(),
-  })
+  () => ({
+    posMap: new Map(),
+  }),
+  (p, posMap?: Map<number, number>) => {
+    if (posMap) p.posMap = posMap;
+    return p;
+  }
 );
 
 EM.registerSerializerPair(

--- a/src/cloth/cloth.ts
+++ b/src/cloth/cloth.ts
@@ -136,12 +136,12 @@ EM.addEagerInit([ClothConstructDef], [], [], () => {
     (cloths, res) => {
       for (let cloth of cloths) {
         if (FinishedDef.isOn(cloth)) continue;
-        EM.ensureComponentOn(cloth, PositionDef, cloth.clothConstruct.location);
-        EM.ensureComponentOn(cloth, ColorDef, cloth.clothConstruct.color);
+        EM.set(cloth, PositionDef, cloth.clothConstruct.location);
+        EM.set(cloth, ColorDef, cloth.clothConstruct.color);
         const { mesh, posMap } = clothMesh(cloth.clothConstruct);
-        EM.ensureComponentOn(cloth, ClothLocalDef, posMap);
-        EM.ensureComponentOn(cloth, RenderableConstructDef, mesh);
-        EM.ensureComponentOn(
+        EM.set(cloth, ClothLocalDef, posMap);
+        EM.set(cloth, RenderableConstructDef, mesh);
+        EM.set(
           cloth,
           SpringGridDef,
           SpringType.SimpleDistance,
@@ -155,12 +155,12 @@ EM.addEagerInit([ClothConstructDef], [], [], () => {
           ],
           cloth.clothConstruct.distance
         );
-        EM.ensureComponentOn(cloth, ForceDef);
-        EM.ensureComponentOn(cloth, AuthorityDef, res.me.pid);
-        EM.ensureComponentOn(cloth, SyncDef);
+        EM.set(cloth, ForceDef);
+        EM.set(cloth, AuthorityDef, res.me.pid);
+        EM.set(cloth, SyncDef);
         cloth.sync.dynamicComponents = [ClothConstructDef.id];
         cloth.sync.fullComponents = [PositionDef.id, ForceDef.id];
-        EM.ensureComponentOn(cloth, FinishedDef);
+        EM.set(cloth, FinishedDef);
       }
     }
   );

--- a/src/cloth/cloth.ts
+++ b/src/cloth/cloth.ts
@@ -28,7 +28,7 @@ export interface ClothConstruct {
   columns: number;
   distance: number;
 }
-export const ClothConstructDef = EM.defineComponent2(
+export const ClothConstructDef = EM.defineComponent(
   "clothConstruct",
   () => ({
     location: V(0, 0, 0),
@@ -42,7 +42,7 @@ export const ClothConstructDef = EM.defineComponent2(
   }
 );
 
-export const ClothLocalDef = EM.defineComponent2(
+export const ClothLocalDef = EM.defineComponent(
   "clothLocal",
   () => ({
     posMap: new Map(),

--- a/src/cloth/cloth.ts
+++ b/src/cloth/cloth.ts
@@ -42,15 +42,11 @@ export const ClothConstructDef = EM.defineComponent(
   }
 );
 
-export const ClothLocalDef = EM.defineComponent(
+export const ClothLocalDef = EM.defineNonupdatableComponent(
   "clothLocal",
-  () => ({
-    posMap: new Map(),
-  }),
-  (p, posMap?: Map<number, number>) => {
-    if (posMap) p.posMap = posMap;
-    return p;
-  }
+  (posMap: Map<number, number>) => ({
+    posMap: posMap,
+  })
 );
 
 EM.registerSerializerPair(

--- a/src/cloth/game-cloth.ts
+++ b/src/cloth/game-cloth.ts
@@ -87,7 +87,7 @@ export async function initClothSandbox(hosting: boolean) {
 
   // TODO(@darzu): this shouldn't be necessary
   const m2 = cloneMesh(res.allMeshes.cube.mesh);
-  EM.ensureComponentOn(g, RenderableConstructDef, m2);
+  EM.set(g, RenderableConstructDef, m2);
 
   {
     // vec3.copy(e.position, [-16.85, 7.11, -4.33]);
@@ -109,23 +109,15 @@ export async function initClothSandbox(hosting: boolean) {
   c.cursor3d.maxDistance = 10;
 
   const plane = EM.new();
-  EM.ensureComponentOn(
-    plane,
-    RenderableConstructDef,
-    res.allMeshes.plane.proto
-  );
-  EM.ensureComponentOn(plane, ColorDef, V(0.2, 0.3, 0.2));
-  EM.ensureComponentOn(plane, PositionDef, V(0, -5, 0));
+  EM.set(plane, RenderableConstructDef, res.allMeshes.plane.proto);
+  EM.set(plane, ColorDef, V(0.2, 0.3, 0.2));
+  EM.set(plane, PositionDef, V(0, -5, 0));
 
   const ship = EM.new();
-  EM.ensureComponentOn(ship, RenderableConstructDef, res.allMeshes.ship.proto);
-  EM.ensureComponentOn(ship, ColorDef, ENEMY_SHIP_COLOR);
-  EM.ensureComponentOn(ship, PositionDef, V(20, -2, 0));
-  EM.ensureComponentOn(
-    ship,
-    RotationDef,
-    quat.fromEuler(0, Math.PI * 0.1, 0, quat.create())
-  );
+  EM.set(ship, RenderableConstructDef, res.allMeshes.ship.proto);
+  EM.set(ship, ColorDef, ENEMY_SHIP_COLOR);
+  EM.set(ship, PositionDef, V(20, -2, 0));
+  EM.set(ship, RotationDef, quat.fromEuler(0, Math.PI * 0.1, 0, quat.create()));
 
   // const ocean = EM.newEntity();
   // EM.ensureComponentOn(
@@ -149,20 +141,20 @@ export async function initClothSandbox(hosting: boolean) {
   // );
 
   const box = EM.new();
-  EM.ensureComponentOn(box, RenderableConstructDef, res.allMeshes.cube.proto);
-  EM.ensureComponentOn(box, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(box, PositionDef, V(0, 0, 3));
-  EM.ensureComponentOn(box, RotationDef);
-  EM.ensureComponentOn(box, AngularVelocityDef, V(0, 0.001, 0.001));
-  EM.ensureComponentOn(box, WorldFrameDef);
-  EM.ensureComponentOn(box, ColliderDef, {
+  EM.set(box, RenderableConstructDef, res.allMeshes.cube.proto);
+  EM.set(box, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(box, PositionDef, V(0, 0, 3));
+  EM.set(box, RotationDef);
+  EM.set(box, AngularVelocityDef, V(0, 0.001, 0.001));
+  EM.set(box, WorldFrameDef);
+  EM.set(box, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.cube.aabb,
   });
 
   const cloth = EM.new();
-  EM.ensureComponentOn(cloth, ClothConstructDef, {
+  EM.set(cloth, ClothConstructDef, {
     location: V(0, 0, 0),
     color: V(0.9, 0.9, 0.8),
     rows: 5,
@@ -170,7 +162,7 @@ export async function initClothSandbox(hosting: boolean) {
     distance: 2,
   });
   const F = 100.0;
-  EM.ensureComponentOn(cloth, ForceDef, V(F, F, F));
+  EM.set(cloth, ForceDef, V(F, F, F));
 
   const line = await drawLine(vec3.create(), vec3.create(), V(0, 1, 0));
 

--- a/src/cloth/game-cloth.ts
+++ b/src/cloth/game-cloth.ts
@@ -120,21 +120,21 @@ export async function initClothSandbox(hosting: boolean) {
   EM.set(ship, RotationDef, quat.fromEuler(0, Math.PI * 0.1, 0, quat.create()));
 
   // const ocean = EM.newEntity();
-  // EM.ensureComponentOn(
+  // EM.set(
   //   ocean,
   //   EM.defineComponent("ocean", () => true)
   // );
-  // EM.ensureComponentOn(
+  // EM.set(
   //   ocean,
   //   RenderableConstructDef,
   //   res.allMeshes.ocean.proto
   // );
-  // EM.ensureComponentOn(ocean, ColorDef, [0.0, 0.0, 0.4]);
-  // EM.ensureComponentOn(ocean, PositionDef, [12000, 180, 0]);
+  // EM.set(ocean, ColorDef, [0.0, 0.0, 0.4]);
+  // EM.set(ocean, PositionDef, [12000, 180, 0]);
   // // vec3.scale(ocean.position, ocean.position, scale);
   // const scale = 100.0;
-  // EM.ensureComponentOn(ocean, ScaleDef, [scale, scale, scale]);
-  // EM.ensureComponentOn(
+  // EM.set(ocean, ScaleDef, [scale, scale, scale]);
+  // EM.set(
   //   ocean,
   //   RotationDef,
   //   quat.fromEuler(quat.create(), 0, Math.PI * 0.1, 0)

--- a/src/cloth/spring.ts
+++ b/src/cloth/spring.ts
@@ -88,9 +88,10 @@ export const SpringGridDef = EM.defineComponent(
   }
 );
 
-export const ForceDef = EM.defineComponent(
+export const ForceDef = EM.defineComponent2(
   "force",
-  (v?: vec3) => v ?? vec3.create()
+  () => V(0, 0, 0),
+  (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
 );
 
 EM.registerSerializerPair(

--- a/src/cloth/spring.ts
+++ b/src/cloth/spring.ts
@@ -42,7 +42,7 @@ export interface SpringGrid {
   springType: SpringType;
 }
 
-export const SpringGridDef = EM.defineComponent2(
+export const SpringGridDef = EM.defineComponent(
   "springGrid",
   () => {
     return {
@@ -89,7 +89,7 @@ export const SpringGridDef = EM.defineComponent2(
   }
 );
 
-export const ForceDef = EM.defineComponent2(
+export const ForceDef = EM.defineComponent(
   "force",
   () => V(0, 0, 0),
   (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)

--- a/src/cloth/spring.ts
+++ b/src/cloth/spring.ts
@@ -3,6 +3,7 @@ import { tempVec3 } from "../matrix/temp-pool.js";
 import { EM } from "../ecs/entity-manager.js";
 import { TimeDef } from "../time/time.js";
 import { Phase } from "../ecs/sys-phase.js";
+import { assert } from "../utils/util.js";
 
 const EPSILON = 0.0000000000000000001;
 const VELOCITY_CAP = 1;
@@ -41,9 +42,25 @@ export interface SpringGrid {
   springType: SpringType;
 }
 
-export const SpringGridDef = EM.defineComponent(
+export const SpringGridDef = EM.defineComponent2(
   "springGrid",
+  () => {
+    return {
+      rows: 0,
+      columns: 0,
+      positions: [] as vec3[],
+      prevPositions: [] as vec3[],
+      nextPositions: [] as vec3[],
+      fixed: new Set<number>(),
+      distance: 1,
+      kOnAxis: 5000,
+      kOffAxis: 5000,
+      externalForce: vec3.create(),
+      springType: SpringType.SimpleDistance,
+    };
+  },
   (
+    p,
     springType?: SpringType,
     rows?: number,
     columns?: number,
@@ -52,39 +69,23 @@ export const SpringGridDef = EM.defineComponent(
     kOnAxis?: number,
     kOffAxis?: number
   ) => {
-    springType = springType || SpringType.SimpleDistance;
-    rows = rows || 0;
-    columns = columns || 0;
-    fixed = fixed || [];
-    distance = distance || 1;
-    kOnAxis = kOnAxis || 5000;
-    kOffAxis = kOffAxis || kOnAxis;
-    const positions: vec3[] = [];
-    const prevPositions: vec3[] = [];
-    const nextPositions: vec3[] = [];
-    for (let y = 0; y < rows; y++) {
-      for (let x = 0; x < columns; x++) {
-        let pos = V(x * distance, y * distance, 0);
-        positions.push(pos);
-        prevPositions.push(vec3.clone(pos));
-        nextPositions.push(vec3.create());
+    assert(p.rows === 0 && p.columns === 0);
+    if (springType) p.springType = springType;
+    if (rows) p.rows = rows;
+    if (columns) p.columns = columns;
+    if (fixed) p.fixed = new Set(fixed);
+    if (distance) p.distance = distance;
+    if (kOnAxis) p.kOnAxis = kOnAxis;
+    if (kOffAxis) p.kOffAxis = kOffAxis;
+    for (let y = 0; y < p.rows; y++) {
+      for (let x = 0; x < p.columns; x++) {
+        let pos = V(x * p.distance, y * p.distance, 0);
+        p.positions.push(pos);
+        p.prevPositions.push(vec3.clone(pos));
+        p.nextPositions.push(vec3.create());
       }
     }
-    const externalForce = vec3.create();
-    const fixedSet = new Set(fixed);
-    return {
-      rows,
-      columns,
-      positions,
-      prevPositions,
-      nextPositions,
-      fixed: fixedSet,
-      distance,
-      kOnAxis,
-      kOffAxis,
-      externalForce,
-      springType,
-    };
+    return p;
   }
 );
 

--- a/src/color/color-ecs.ts
+++ b/src/color/color-ecs.ts
@@ -1,9 +1,10 @@
 import { Component, EM } from "../ecs/entity-manager.js";
 import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
 
-export const ColorDef = EM.defineComponent("color", (c?: vec3.InputT) =>
-  // TODO(@darzu): we need a better copy-in vs ref convention
-  vec3.clone(c ?? vec3.ZEROS)
+export const ColorDef = EM.defineComponent2(
+  "color",
+  () => V(0, 0, 0),
+  (p, c?: vec3.InputT) => (c ? vec3.copy(p, c) : p)
 );
 export type Color = Component<typeof ColorDef>;
 
@@ -17,9 +18,10 @@ EM.registerSerializerPair(
   }
 );
 
-export const TintsDef = EM.defineComponent(
+export const TintsDef = EM.defineComponent2(
   "tints",
-  () => new Map() as Map<string, vec3>
+  () => new Map() as Map<string, vec3>,
+  (p) => p
 );
 
 export type Tints = Component<typeof TintsDef>;
@@ -44,5 +46,9 @@ export function clearTint(tints: Tints, name: string) {
   }
 }
 
-export const AlphaDef = EM.defineComponent("alpha", (c?: number) => c ?? 1.0);
+export const AlphaDef = EM.defineComponent2(
+  "alpha",
+  () => 1.0,
+  (p, c?: number) => c ?? p
+);
 export type Alpha = Component<typeof AlphaDef>;

--- a/src/color/color-ecs.ts
+++ b/src/color/color-ecs.ts
@@ -20,8 +20,7 @@ EM.registerSerializerPair(
 
 export const TintsDef = EM.defineComponent(
   "tints",
-  () => new Map() as Map<string, vec3>,
-  (p) => p
+  () => new Map() as Map<string, vec3>
 );
 
 export type Tints = Component<typeof TintsDef>;

--- a/src/color/color-ecs.ts
+++ b/src/color/color-ecs.ts
@@ -1,7 +1,7 @@
 import { Component, EM } from "../ecs/entity-manager.js";
 import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
 
-export const ColorDef = EM.defineComponent2(
+export const ColorDef = EM.defineComponent(
   "color",
   () => V(0, 0, 0),
   (p, c?: vec3.InputT) => (c ? vec3.copy(p, c) : p)
@@ -18,7 +18,7 @@ EM.registerSerializerPair(
   }
 );
 
-export const TintsDef = EM.defineComponent2(
+export const TintsDef = EM.defineComponent(
   "tints",
   () => new Map() as Map<string, vec3>,
   (p) => p
@@ -46,7 +46,7 @@ export function clearTint(tints: Tints, name: string) {
   }
 }
 
-export const AlphaDef = EM.defineComponent2(
+export const AlphaDef = EM.defineComponent(
   "alpha",
   () => 1.0,
   (p, c?: number) => c ?? p

--- a/src/debug/ghost.ts
+++ b/src/debug/ghost.ts
@@ -9,11 +9,7 @@ import { ControllableDef } from "../input/controllable.js";
 // TODO(@darzu): HACK. we need a better way to programmatically create sandbox games
 export const gameplaySystems: string[] = [];
 
-export const GhostDef = EM.defineComponent(
-  "ghost",
-  () => ({}),
-  (p) => p
-);
+export const GhostDef = EM.defineComponent("ghost", () => ({}));
 
 export function createGhost() {
   const g = EM.new();

--- a/src/debug/ghost.ts
+++ b/src/debug/ghost.ts
@@ -9,7 +9,7 @@ import { ControllableDef } from "../input/controllable.js";
 // TODO(@darzu): HACK. we need a better way to programmatically create sandbox games
 export const gameplaySystems: string[] = [];
 
-export const GhostDef = EM.defineComponent2(
+export const GhostDef = EM.defineComponent(
   "ghost",
   () => ({}),
   (p) => p

--- a/src/debug/ghost.ts
+++ b/src/debug/ghost.ts
@@ -13,19 +13,19 @@ export const GhostDef = EM.defineComponent("ghost", () => ({}));
 
 export function createGhost() {
   const g = EM.new();
-  EM.ensureComponentOn(g, GhostDef);
-  EM.ensureComponentOn(g, ControllableDef);
+  EM.set(g, GhostDef);
+  EM.set(g, ControllableDef);
   g.controllable.modes.canFall = false;
   g.controllable.modes.canJump = false;
   // g.controllable.modes.canYaw = true;
   // g.controllable.modes.canPitch = true;
-  EM.ensureComponentOn(g, CameraFollowDef, 1);
+  EM.set(g, CameraFollowDef, 1);
   setCameraFollowPosition(g, "firstPerson");
-  EM.ensureComponentOn(g, PositionDef);
-  EM.ensureComponentOn(g, RotationDef);
+  EM.set(g, PositionDef);
+  EM.set(g, RotationDef);
   // quat.rotateY(g.rotation, quat.IDENTITY, (-5 * Math.PI) / 8);
   // quat.rotateX(g.cameraFollow.rotationOffset, quat.IDENTITY, -Math.PI / 8);
-  EM.ensureComponentOn(g, LinearVelocityDef);
+  EM.set(g, LinearVelocityDef);
 
   return g;
 }

--- a/src/debug/ghost.ts
+++ b/src/debug/ghost.ts
@@ -9,7 +9,11 @@ import { ControllableDef } from "../input/controllable.js";
 // TODO(@darzu): HACK. we need a better way to programmatically create sandbox games
 export const gameplaySystems: string[] = [];
 
-export const GhostDef = EM.defineComponent("ghost", () => ({}));
+export const GhostDef = EM.defineComponent2(
+  "ghost",
+  () => ({}),
+  (p) => p
+);
 
 export function createGhost() {
   const g = EM.new();

--- a/src/debug/utils-gizmos.ts
+++ b/src/debug/utils-gizmos.ts
@@ -65,24 +65,24 @@ export function createGraph3D(
   // TODO(@darzu): maybe everything should be created with a scale
   const graphMesh = createGraph3DAxesMesh(opts);
   const graph = EM.new();
-  EM.ensureComponentOn(graph, RenderableConstructDef, graphMesh);
-  EM.ensureComponentOn(graph, PositionDef, pos);
+  EM.set(graph, RenderableConstructDef, graphMesh);
+  EM.set(graph, PositionDef, pos);
 
   const surfScale = vec3.div(worldSize, domainSize, vec3.create());
   // console.log(`surfScale: ${vec3Dbg(surfScale)}`);
 
   const graphSurf = EM.new();
   const graphSurfMesh = createGraph3DDataMesh(data);
-  EM.ensureComponentOn(graphSurf, RenderableConstructDef, graphSurfMesh);
-  EM.ensureComponentOn(
+  EM.set(graphSurf, RenderableConstructDef, graphSurfMesh);
+  EM.set(
     graphSurf,
     PositionDef,
     vec3.mul(vec3.negate(domain.min), surfScale, vec3.create())
     // vec3.add(worldGizmo.position, [50, 10, 50], V(0, 0, 0))
   );
-  EM.ensureComponentOn(graphSurf, PhysicsParentDef, graph.id);
-  EM.ensureComponentOn(graphSurf, ColorDef, color);
-  EM.ensureComponentOn(graphSurf, ScaleDef, surfScale);
+  EM.set(graphSurf, PhysicsParentDef, graph.id);
+  EM.set(graphSurf, ColorDef, color);
+  EM.set(graphSurf, ScaleDef, surfScale);
 
   return graph;
 }

--- a/src/debug/xp-cube.ts
+++ b/src/debug/xp-cube.ts
@@ -52,7 +52,7 @@ export async function initCubeGame() {
 
   // TODO(@darzu): this shouldn't be necessary
   const m2 = cloneMesh(res.allMeshes.cube.mesh);
-  EM.ensureComponentOn(e, RenderableConstructDef, m2);
+  EM.set(e, RenderableConstructDef, m2);
 
   {
     // auto-gen; use dbg.saveCamera() to update
@@ -69,13 +69,13 @@ export async function initCubeGame() {
   boxM.colors = boxM.surfaceIds.map((_, i) => uintToVec3unorm(i, sIdMax));
   // boxM.colors = boxM.surfaceIds.map((_, i) => [0.1, i / 12, 0.1]);
   // console.dir(boxM.colors);
-  EM.ensureComponentOn(box, RenderableConstructDef, boxM);
+  EM.set(box, RenderableConstructDef, boxM);
   // EM.ensureComponentOn(box, ColorDef, [0.1, 0.4, 0.1]);
-  EM.ensureComponentOn(box, PositionDef, V(0, 0, 3));
-  EM.ensureComponentOn(box, RotationDef);
-  EM.ensureComponentOn(box, AngularVelocityDef, V(0, 0.001, 0.001));
-  EM.ensureComponentOn(box, WorldFrameDef);
-  EM.ensureComponentOn(box, ColliderDef, {
+  EM.set(box, PositionDef, V(0, 0, 3));
+  EM.set(box, RotationDef);
+  EM.set(box, AngularVelocityDef, V(0, 0.001, 0.001));
+  EM.set(box, WorldFrameDef);
+  EM.set(box, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.cube.aabb,

--- a/src/debug/xp-cube.ts
+++ b/src/debug/xp-cube.ts
@@ -70,7 +70,7 @@ export async function initCubeGame() {
   // boxM.colors = boxM.surfaceIds.map((_, i) => [0.1, i / 12, 0.1]);
   // console.dir(boxM.colors);
   EM.set(box, RenderableConstructDef, boxM);
-  // EM.ensureComponentOn(box, ColorDef, [0.1, 0.4, 0.1]);
+  // EM.set(box, ColorDef, [0.1, 0.4, 0.1]);
   EM.set(box, PositionDef, V(0, 0, 3));
   EM.set(box, RotationDef);
   EM.set(box, AngularVelocityDef, V(0, 0.001, 0.001));

--- a/src/ecs/delete.ts
+++ b/src/ecs/delete.ts
@@ -4,13 +4,9 @@ import { dbgLogOnce } from "../utils/util.js";
 import { Phase } from "./sys-phase.js";
 import { WARN_DEAD_CLEANUP } from "../flags.js";
 
-export const DeletedDef = EM.defineComponent(
-  "deleted",
-  () => ({
-    processed: false,
-  }),
-  (p) => p
-);
+export const DeletedDef = EM.defineComponent("deleted", () => ({
+  processed: false,
+}));
 
 EM.registerSerializerPair(
   DeletedDef,
@@ -43,21 +39,16 @@ EM.addSystem("delete", Phase.PRE_GAME_WORLD, [DeletedDef], [], (entities) => {
 // TODO(@darzu): uh oh. this seems like memory/life cycle management.
 //    currently this is needed for entities that "own" other
 //    entities but might be deleted in several ways
-export const OnDeleteDef = EM.defineComponent(
+export const OnDeleteDef = EM.defineNonupdatableComponent(
   "onDelete",
-  () => (deletedId: number) => {},
-  (p, onDelete: (deletedId: number) => void) => onDelete
+  (onDelete: (deletedId: number) => void) => onDelete
 );
 
 // Idea: needed for entity pools. EM wont call a system w/ a Dead entity unless
 //    that system explicitly asks for Dead.
-export const DeadDef = EM.defineComponent(
-  "dead",
-  () => ({
-    processed: false,
-  }),
-  (p) => p
-);
+export const DeadDef = EM.defineComponent("dead", () => ({
+  processed: false,
+}));
 
 // TODO(@darzu): this is entity specific...
 if (WARN_DEAD_CLEANUP) {

--- a/src/ecs/delete.ts
+++ b/src/ecs/delete.ts
@@ -4,9 +4,13 @@ import { dbgLogOnce } from "../utils/util.js";
 import { Phase } from "./sys-phase.js";
 import { WARN_DEAD_CLEANUP } from "../flags.js";
 
-export const DeletedDef = EM.defineComponent("deleted", () => ({
-  processed: false,
-}));
+export const DeletedDef = EM.defineComponent2(
+  "deleted",
+  () => ({
+    processed: false,
+  }),
+  (p) => p
+);
 
 EM.registerSerializerPair(
   DeletedDef,
@@ -39,16 +43,21 @@ EM.addSystem("delete", Phase.PRE_GAME_WORLD, [DeletedDef], [], (entities) => {
 // TODO(@darzu): uh oh. this seems like memory/life cycle management.
 //    currently this is needed for entities that "own" other
 //    entities but might be deleted in several ways
-export const OnDeleteDef = EM.defineComponent(
+export const OnDeleteDef = EM.defineComponent2(
   "onDelete",
-  (onDelete: (deletedId: number) => void) => onDelete
+  () => (deletedId: number) => {},
+  (p, onDelete: (deletedId: number) => void) => onDelete
 );
 
 // Idea: needed for entity pools. EM wont call a system w/ a Dead entity unless
 //    that system explicitly asks for Dead.
-export const DeadDef = EM.defineComponent("dead", () => ({
-  processed: false,
-}));
+export const DeadDef = EM.defineComponent2(
+  "dead",
+  () => ({
+    processed: false,
+  }),
+  (p) => p
+);
 
 // TODO(@darzu): this is entity specific...
 if (WARN_DEAD_CLEANUP) {

--- a/src/ecs/delete.ts
+++ b/src/ecs/delete.ts
@@ -4,7 +4,7 @@ import { dbgLogOnce } from "../utils/util.js";
 import { Phase } from "./sys-phase.js";
 import { WARN_DEAD_CLEANUP } from "../flags.js";
 
-export const DeletedDef = EM.defineComponent2(
+export const DeletedDef = EM.defineComponent(
   "deleted",
   () => ({
     processed: false,
@@ -43,7 +43,7 @@ EM.addSystem("delete", Phase.PRE_GAME_WORLD, [DeletedDef], [], (entities) => {
 // TODO(@darzu): uh oh. this seems like memory/life cycle management.
 //    currently this is needed for entities that "own" other
 //    entities but might be deleted in several ways
-export const OnDeleteDef = EM.defineComponent2(
+export const OnDeleteDef = EM.defineComponent(
   "onDelete",
   () => (deletedId: number) => {},
   (p, onDelete: (deletedId: number) => void) => onDelete
@@ -51,7 +51,7 @@ export const OnDeleteDef = EM.defineComponent2(
 
 // Idea: needed for entity pools. EM wont call a system w/ a Dead entity unless
 //    that system explicitly asks for Dead.
-export const DeadDef = EM.defineComponent2(
+export const DeadDef = EM.defineComponent(
   "dead",
   () => ({
     processed: false,

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -132,12 +132,11 @@ export function defineNetEntityHelper<
     propsDef,
     [...opts.buildResources, MeDef],
     (e, res) => {
-      // TYPE HACK
-      const me = (res as any as Resources<[typeof MeDef]>).me;
-      EM.set(e, AuthorityDef, me.pid);
-      console.log(
-        `making ent ${e.id} w/ pid ${me.pid}; actual: ${e.authority.pid}`
-      );
+      const me = (res as any as Resources<[typeof MeDef]>).me; // TYPE HACK
+      if (!AuthorityDef.isOn(e)) EM.set(e, AuthorityDef, me.pid);
+      // console.log(
+      //   `making ent ${e.id} w/ pid ${me.pid}; actual: ${e.authority.pid}`
+      // );
 
       EM.set(e, localDef);
       EM.set(e, SyncDef);

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -47,7 +47,7 @@ function registerConstructorSystem<
       for (let e of es) {
         if (FinishedDef.isOn(e)) continue;
         callback(e as EntityW<[C]>, res);
-        EM.ensureComponentOn(e, FinishedDef);
+        EM.set(e, FinishedDef);
       }
     }
   );
@@ -134,13 +134,13 @@ export function defineNetEntityHelper<
     (e, res) => {
       // TYPE HACK
       const me = (res as any as Resources<[typeof MeDef]>).me;
-      EM.ensureComponentOn(e, AuthorityDef, me.pid);
+      EM.set(e, AuthorityDef, me.pid);
 
-      EM.ensureComponentOn(e, localDef);
-      EM.ensureComponentOn(e, SyncDef);
+      EM.set(e, localDef);
+      EM.set(e, SyncDef);
       e.sync.fullComponents = [propsDef.id];
       e.sync.dynamicComponents = opts.dynamicComponents.map((d) => d.id);
-      for (let d of opts.dynamicComponents) EM.ensureComponentOn(e, d);
+      for (let d of opts.dynamicComponents) EM.set(e, d);
 
       // TYPE HACK
       const _e = e as any as EntityW<
@@ -159,17 +159,17 @@ export function defineNetEntityHelper<
 
   const createNew = (...args: Pargs1) => {
     const e = EM.new();
-    EM.ensureComponentOn(e, propsDef, ...args);
+    EM.set(e, propsDef, ...args);
     return e;
   };
 
   const createNewNow = (res: Resources<RS>, ...args: Pargs1) => {
     const e = EM.new();
-    EM.ensureComponentOn(e, propsDef, ...args);
+    EM.set(e, propsDef, ...args);
     // TODO(@darzu): maybe we should force users to give us the MeDef? it's probably always there tho..
     // TODO(@darzu): Think about what if buid() is async...
     constructFn(e, res as Resources<[...RS, typeof MeDef]>);
-    EM.ensureComponentOn(e, FinishedDef);
+    EM.set(e, FinishedDef);
     return e;
   };
 

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -119,7 +119,11 @@ export function defineNetEntityHelper<
     opts.serializeProps,
     opts.deserializeProps
   );
-  const localDef = EM.defineComponent(`${opts.name}Local`, opts.defaultLocal);
+  const localDef = EM.defineComponent2(
+    `${opts.name}Local`,
+    opts.defaultLocal,
+    (p) => p
+  );
 
   const constructFn = registerConstructorSystem(
     propsDef,
@@ -216,4 +220,8 @@ export function createRef<CS extends ComponentDef[]>(
   }
 }
 
-export const FinishedDef = EM.defineComponent("finished", () => true);
+export const FinishedDef = EM.defineComponent2(
+  "finished",
+  () => true,
+  (p) => p
+);

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -133,16 +133,16 @@ export function defineNetEntityHelper<
     [...opts.buildResources, MeDef],
     (e, res) => {
       const me = (res as any as Resources<[typeof MeDef]>).me; // TYPE HACK
-      if (!AuthorityDef.isOn(e)) EM.set(e, AuthorityDef, me.pid);
+      EM.setOnce(e, AuthorityDef, me.pid);
       // console.log(
       //   `making ent ${e.id} w/ pid ${me.pid}; actual: ${e.authority.pid}`
       // );
 
-      EM.set(e, localDef);
-      EM.set(e, SyncDef);
+      EM.setOnce(e, localDef);
+      EM.setOnce(e, SyncDef);
       e.sync.fullComponents = [propsDef.id];
       e.sync.dynamicComponents = opts.dynamicComponents.map((d) => d.id);
-      for (let d of opts.dynamicComponents) EM.set(e, d);
+      for (let d of opts.dynamicComponents) EM.setOnce(e, d); // TODO(@darzu): this makes me nervous, calling .set without parameters
 
       // TYPE HACK
       const _e = e as any as EntityW<

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -25,7 +25,7 @@ export function defineSerializableComponent<
   serialize: (obj: P, buf: Serializer) => void,
   deserialize: (obj: P, buf: Deserializer) => void
 ): ComponentDef<N, P, [], UArgs> {
-  const def = EM.defineComponent2(name, make, update);
+  const def = EM.defineComponent(name, make, update);
   EM.registerSerializerPair(def, serialize, deserialize);
   return def;
 }
@@ -122,7 +122,7 @@ export function defineNetEntityHelper<
     opts.serializeProps,
     opts.deserializeProps
   );
-  const localDef = EM.defineComponent2(
+  const localDef = EM.defineComponent(
     `${opts.name}Local`,
     opts.defaultLocal,
     (p) => p
@@ -223,7 +223,7 @@ export function createRef<CS extends ComponentDef[]>(
   }
 }
 
-export const FinishedDef = EM.defineComponent2(
+export const FinishedDef = EM.defineComponent(
   "finished",
   () => true,
   (p) => p

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -135,6 +135,9 @@ export function defineNetEntityHelper<
       // TYPE HACK
       const me = (res as any as Resources<[typeof MeDef]>).me;
       EM.set(e, AuthorityDef, me.pid);
+      console.log(
+        `making ent ${e.id} w/ pid ${me.pid}; actual: ${e.authority.pid}`
+      );
 
       EM.set(e, localDef);
       EM.set(e, SyncDef);

--- a/src/ecs/em-helpers.ts
+++ b/src/ecs/em-helpers.ts
@@ -18,11 +18,14 @@ export function defineSerializableComponent<
   Pargs extends any[]
 >(
   name: N,
-  construct: (...args: Pargs) => P,
+  // TODO(@darzu): change to use update/make
+  // construct: (...args: Pargs) => P,
+  make: () => P,
+  update: (p: P, ...args: Pargs) => P,
   serialize: (obj: P, buf: Serializer) => void,
   deserialize: (obj: P, buf: Deserializer) => void
 ): ComponentDef<N, P, Pargs> {
-  const def = EM.defineComponent(name, construct);
+  const def = EM.defineComponent2(name, make, update);
   EM.registerSerializerPair(def, serialize, deserialize);
   return def;
 }
@@ -87,7 +90,8 @@ export function defineNetEntityHelper<
   INITED
 >(opts: {
   name: N;
-  defaultProps: (...args: Pargs1) => P1;
+  defaultProps: () => P1;
+  updateProps: (p: P1, ...args: Pargs1) => P1;
   serializeProps: (obj: P1, buf: Serializer) => void;
   deserializeProps: (obj: P1, buf: Deserializer) => void;
   defaultLocal: () => P2;
@@ -111,6 +115,7 @@ export function defineNetEntityHelper<
   const propsDef = defineSerializableComponent(
     `${opts.name}Props`,
     opts.defaultProps,
+    opts.updateProps,
     opts.serializeProps,
     opts.deserializeProps
   );

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -296,9 +296,7 @@ export class EntityManager {
   ): ComponentDef<N, P, Pargs> {
     // TODO(@darzu): Remove!
     const construct = (...args: Pargs) => {
-      const p = make();
-      update(p, ...args);
-      return p;
+      return update(make(), ...args);
     };
     return this.defineComponent(name, construct);
   }

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -44,7 +44,12 @@ export interface ResourceDef<
 }
 
 export type CompId = number;
-// TODO(@darzu): we should seperate component vs resource def
+
+// TODO(@darzu): Consider having a "NonsyncableComponentDef" or "NonupdatableComponentDef" that
+//  can take constructor args but can't be synced and throws an error if u use EM.set twice since
+//  it can't update. See "NonUpdatableComponentDef" branch for one attempt, but i ran into type
+//  issues i couldn't fix.
+
 export interface ComponentDef<
   N extends string = string,
   P = any,

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -264,10 +264,9 @@ export class EntityManager {
 
   constructor() {
     // dummy ent 0
-    const ent0 = Object.create(null); // no prototype
-    ent0.id = 0;
-    this.entities.set(0, ent0);
-    // TODO(@darzu): maintain _entitiesToSystems for ent 0?
+    // const ent0 = Object.create(null); // no prototype
+    // ent0.id = 0;
+    // this.entities.set(0, ent0);
   }
 
   public defineResource<N extends string, P, Pargs extends any[]>(
@@ -286,6 +285,22 @@ export class EntityManager {
     };
     this.resourceDefs.set(id, def);
     return def;
+  }
+
+  // TODO(@darzu): REFACTOR! Consolidate w/ defineComponent below
+  public defineComponent2<N extends string, P, Pargs extends any[]>(
+    name: N,
+    // construct: (...args: Pargs) => P
+    make: () => P,
+    update: (p: P, ...args: Pargs) => P
+  ): ComponentDef<N, P, Pargs> {
+    // TODO(@darzu): Remove!
+    const construct = (...args: Pargs) => {
+      const p = make();
+      update(p, ...args);
+      return p;
+    };
+    return this.defineComponent(name, construct);
   }
 
   public defineComponent<N extends string, P, Pargs extends any[]>(

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -273,11 +273,9 @@ export class EntityManager {
     return def;
   }
 
-  // TODO(@darzu): REFACTOR! Consolidate w/ defineComponent below
   public defineComponent<N extends string, P, UArgs extends any[] = []>(
     name: N,
-    // construct: (...args: Pargs) => P
-    make: () => P,
+    construct: () => P,
     update: (p: P, ...args: UArgs) => P = (p, ..._) => p
   ): UpdatableComponentDef<N, P, UArgs> {
     const id = nameToId(name);
@@ -288,10 +286,8 @@ export class EntityManager {
       _brand: "componentDef", // TODO(@darzu): remove?
       updatable: true,
       name,
-      construct: make,
+      construct,
       update,
-      // make,
-      // update,
       id,
       isOn: <E extends Entity>(e: E): e is E & { [K in N]: P } =>
         // (e as Object).hasOwn(name),
@@ -302,12 +298,9 @@ export class EntityManager {
     return component;
   }
 
-  // TODO(@darzu): REFACTOR: return a different component type?
   public defineNonupdatableComponent<N extends string, P, CArgs extends any[]>(
     name: N,
     construct: (...args: CArgs) => P
-    // make: () => P,
-    // update: (p: P, ...args: Pargs) => P
   ): NonupdatableComponentDef<N, P, CArgs> {
     const id = nameToId(name);
     if (this.components.has(id)) {
@@ -326,8 +319,6 @@ export class EntityManager {
         // (e as Object).hasOwn(name),
         name in e,
     };
-    // // TODO(@darzu): I don't love this cast. feels like it should be possible without..
-    // this.components.set(id, component as unknown as ComponentDef);
     this.components.set(id, component);
     return component;
   }

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -281,7 +281,7 @@ export class EntityManager {
   }
 
   // TODO(@darzu): REFACTOR! Consolidate w/ defineComponent below
-  public defineComponent<N extends string, P, UArgs extends any[]>(
+  public defineComponent<N extends string, P, UArgs extends any[] = []>(
     name: N,
     // construct: (...args: Pargs) => P
     make: () => P,

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -536,9 +536,6 @@ export class EntityManager {
       return (e as any)[def.name];
     }
   }
-  // TODO(@darzu): do we want to make this the standard way we do ensureComponent and addComponent ?
-  // TODO(@darzu): rename to "set" and have "maybeSet" w/ a thunk as a way to short circuit unnecessary init?
-  //      and maybe "strictSet" as the version that throws if it exists (renamed from "addComponent")
   public set<N extends string, P, PArgs extends any[]>(
     e: Entity,
     def: UpdatableComponentDef<N, P, PArgs>,
@@ -563,6 +560,17 @@ export class EntityManager {
         `Trying to double set non-updatable component '${def.name}' on '${e.id}'`
       );
       (e as any)[def.name] = def.update((e as any)[def.name], ...args);
+    }
+  }
+
+  public setOnce<N extends string, P, PArgs extends any[]>(
+    e: Entity,
+    def: NonupdatableComponentDef<N, P, PArgs>,
+    ...args: PArgs
+  ): asserts e is EntityW<[NonupdatableComponentDef<N, P, PArgs>]> {
+    const alreadyHas = def.name in e;
+    if (!alreadyHas) {
+      this.addComponent(e.id, def, ...args);
     }
   }
 

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -53,42 +53,14 @@ export type CompId = number;
 export interface ComponentDef<
   N extends string = string,
   P = any,
-  Pargs extends any[] = any[]
+  CArgs extends any[] = any,
+  UArgs extends any[] = any
 > {
   _brand: "componentDef"; // TODO(@darzu): remove once ResourceDef & ComponentDef are incompatible
+  updatable: boolean;
   readonly name: N;
-  // TODO(@darzu): Instead of a constructor, we should require a copy fn that can
-  //  both initialize a new obj or copy new properties into an existing one. This
-  //  is really important for entity pools where entities are re-used and we need
-  //  to either "create new component with properties or stamp these properties
-  //  into existing component". Than method doesnt exist yet b/c we lack a standard
-  //  copy/construct fn.
-  // TODO(@darzu): while we're at it, we might require that components are always
-  //  objects. E.g. no naked numbers or booleans. There's some other reason i think
-  //  we want this that is eluding me..
-  /* 
-  TODO(@darzu):
-    ? require a copy fn and a () => P constructor
-    no way to have EM.set(ent, V(0,0,0)) w/o copy fn b/c it may exist
-    EM.add: for must-not-exist-yet add a component
-    EM.set: add or set, requires copy fn
-    EM.update: must exist already, requires copy fn
-    could be all components are objects
-      default copy fn is just object.assign
-    if we have term-level field info, we could have a default serializer/deserializer
-      but we like to either write those by hand or rely on a compile pass which can use type info
-    how important is taking in ...args as opposed to a P?
-    could have constructor fn `() => P` and update fn `(p: P, ...args: Pargs) => void`
-    better to put more burden at component def time than EM.set time
-    how do these interact with deserialize?
-    copy is just one type of update
-    construct + update
-    that would solve my bug, b/c u must provide ()=>P
-    deserialization is just one kind of update
-    for entity pools, since the components would exist, the update would be natural?
-      could skip seperating the create & onSpawn? nah. well maybe optionally.
-  */
-  construct: (...args: Pargs) => P;
+  construct: (...args: CArgs) => P;
+  update: (p: P, ...args: UArgs) => P;
   // make: () => P;
   // update: (p: P, ...args: Pargs) => P;
   readonly id: CompId;
@@ -293,33 +265,51 @@ export class EntityManager {
   }
 
   // TODO(@darzu): REFACTOR! Consolidate w/ defineComponent below
-  public defineComponent2<N extends string, P, Pargs extends any[]>(
+  public defineComponent2<N extends string, P, UArgs extends any[]>(
     name: N,
     // construct: (...args: Pargs) => P
     make: () => P,
-    update: (p: P, ...args: Pargs) => P
-  ): ComponentDef<N, P, Pargs> {
-    // TODO(@darzu): Remove!
-    const construct = (...args: Pargs) => {
-      return update(make(), ...args);
-    };
-    return this.defineComponent(name, construct);
-  }
-
-  public defineComponent<N extends string, P, Pargs extends any[]>(
-    name: N,
-    construct: (...args: Pargs) => P
-    // make: () => P,
-    // update: (p: P, ...args: Pargs) => P
-  ): ComponentDef<N, P, Pargs> {
+    update: (p: P, ...args: UArgs) => P
+  ): ComponentDef<N, P, [], UArgs> {
     const id = nameToId(name);
     if (this.components.has(id)) {
       throw `Component with name ${name} already defined--hash collision?`;
     }
-    const component: ComponentDef<N, P, Pargs> = {
+    const component: ComponentDef<N, P, [], UArgs> = {
       _brand: "componentDef", // TODO(@darzu): remove?
+      updatable: true,
+      name,
+      construct: make,
+      update,
+      // make,
+      // update,
+      id,
+      isOn: <E extends Entity>(e: E): e is E & { [K in N]: P } =>
+        // (e as Object).hasOwn(name),
+        name in e,
+    };
+    // TODO(@darzu): I don't love this cast. feels like it should be possible without..
+    this.components.set(id, component as unknown as ComponentDef);
+    return component;
+  }
+
+  // TODO(@darzu): REFACTOR: return a different component type?
+  public defineComponent<N extends string, P, CArgs extends any[]>(
+    name: N,
+    construct: (...args: CArgs) => P
+    // make: () => P,
+    // update: (p: P, ...args: Pargs) => P
+  ): ComponentDef<N, P, CArgs, []> {
+    const id = nameToId(name);
+    if (this.components.has(id)) {
+      throw `Component with name ${name} already defined--hash collision?`;
+    }
+    const component: ComponentDef<N, P, CArgs, []> = {
+      _brand: "componentDef", // TODO(@darzu): remove?
+      updatable: false,
       name,
       construct,
+      update: (p) => p,
       // make,
       // update,
       id,
@@ -333,9 +323,7 @@ export class EntityManager {
     return component;
   }
 
-  private checkComponent<N extends string, P, Pargs extends any[]>(
-    def: ComponentDef<N, P, Pargs>
-  ) {
+  private checkComponent(def: ComponentDef) {
     if (!this.components.has(def.id))
       throw `Component ${def.name} (id ${def.id}) not found`;
     if (this.components.get(def.id)!.name !== def.name)
@@ -344,8 +332,8 @@ export class EntityManager {
       }, not ${def.name}`;
   }
 
-  public registerSerializerPair<N extends string, P, Pargs extends any[]>(
-    def: ComponentDef<N, P, Pargs>,
+  public registerSerializerPair<N extends string, P, UArgs extends any[]>(
+    def: ComponentDef<N, P, [], UArgs>,
     serialize: (obj: P, buf: Serializer) => void,
     deserialize: (obj: P, buf: Deserializer) => void
   ) {
@@ -451,14 +439,19 @@ export class EntityManager {
   private isDeadE(e: Entity) {
     return "dead" in e;
   }
-  private isDeadC(e: ComponentDef<any, any, any>) {
+  private isDeadC(e: ComponentDef) {
     return "dead" === e.name;
   }
 
-  public addComponent<N extends string, P, Pargs extends any[] = any[]>(
+  public addComponent<
+    N extends string,
+    P,
+    CArgs extends any[],
+    UArgs extends any[]
+  >(
     id: number,
-    def: ComponentDef<N, P, Pargs>,
-    ...args: Pargs
+    def: ComponentDef<N, P, CArgs, UArgs>,
+    ...args: [...CArgs, ...UArgs] // TODO(@darzu): REFACTOR. Types aren't right yet
   ): P {
     this.checkComponent(def);
     if (id === 0) throw `hey, use addResource!`;
@@ -471,7 +464,11 @@ export class EntityManager {
     }
     if (def.name in e)
       throw `double defining component ${def.name} on ${e.id}!`;
-    const c = def.construct(...args);
+    // TODO(@darzu): REFACTOR:
+    // TODO(@darzu): HACK. Types aren't right..
+    let c = def.construct(...(args as unknown as CArgs));
+    c = def.update(c, ...(args as unknown as UArgs));
+
     // let c = def.make();
     // c = def.update(c, ...args);
     (e as any)[def.name] = c;
@@ -521,10 +518,15 @@ export class EntityManager {
     return this.addComponent(id, component, ...args);
   }
 
-  public ensureComponent<N extends string, P, Pargs extends any[] = any[]>(
+  public ensureComponent<
+    N extends string,
+    P,
+    CArgs extends any[],
+    UArgs extends any[]
+  >(
     id: number,
-    def: ComponentDef<N, P, Pargs>,
-    ...args: Pargs
+    def: ComponentDef<N, P, CArgs, UArgs>,
+    ...args: [...CArgs, ...UArgs]
   ): P {
     this.checkComponent(def);
     const e = this.entities.get(id)!;
@@ -538,15 +540,25 @@ export class EntityManager {
   // TODO(@darzu): do we want to make this the standard way we do ensureComponent and addComponent ?
   // TODO(@darzu): rename to "set" and have "maybeSet" w/ a thunk as a way to short circuit unnecessary init?
   //      and maybe "strictSet" as the version that throws if it exists (renamed from "addComponent")
-  public ensureComponentOn<N extends string, P, Pargs extends any[] = []>(
+  public ensureComponentOn<
+    N extends string,
+    P,
+    CArgs extends any[] = [],
+    UArgs extends any[] = []
+  >(
     e: Entity,
-    def: ComponentDef<N, P, Pargs>,
-    ...args: Pargs
-  ): asserts e is EntityW<[ComponentDef<N, P, Pargs>]> {
+    def: ComponentDef<N, P, CArgs, UArgs>,
+    ...args: [...CArgs, ...UArgs]
+  ): asserts e is EntityW<[ComponentDef<N, P, CArgs, UArgs>]> {
     const alreadyHas = def.name in e;
     // assert(!alreadyHas, `${e.id} already has ${def.name}`);
     if (!alreadyHas) {
+      // TODO(@darzu): REFACTOR. types aren't right yet
       this.addComponent(e.id, def, ...args);
+    } else {
+      // TODO(@darzu): REFACTOR:
+      // assert(def.updatable, `Cannot `
+      // def.update
     }
   }
 

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -265,7 +265,7 @@ export class EntityManager {
   }
 
   // TODO(@darzu): REFACTOR! Consolidate w/ defineComponent below
-  public defineComponent2<N extends string, P, UArgs extends any[]>(
+  public defineComponent<N extends string, P, UArgs extends any[]>(
     name: N,
     // construct: (...args: Pargs) => P
     make: () => P,
@@ -294,7 +294,7 @@ export class EntityManager {
   }
 
   // TODO(@darzu): REFACTOR: return a different component type?
-  public defineComponent<N extends string, P, CArgs extends any[]>(
+  public defineNonupdatableComponent<N extends string, P, CArgs extends any[]>(
     name: N,
     construct: (...args: CArgs) => P
     // make: () => P,

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -285,7 +285,7 @@ export class EntityManager {
     name: N,
     // construct: (...args: Pargs) => P
     make: () => P,
-    update: (p: P, ...args: UArgs) => P
+    update: (p: P, ...args: UArgs) => P = (p, ..._) => p
   ): UpdatableComponentDef<N, P, UArgs> {
     const id = nameToId(name);
     if (this.components.has(id)) {

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -37,7 +37,7 @@ export interface ResourceDef<
   P = any,
   Pargs extends any[] = any[]
 > {
-  _brand: "resourceDef"; // TODO(@darzu): remove once ResourceDef & ComponentDef are incompatible
+  _brand: "resourceDef";
   readonly id: ResId;
   readonly name: N;
   construct: (...args: Pargs) => P;
@@ -45,24 +45,17 @@ export interface ResourceDef<
 
 export type CompId = number;
 
-// TODO(@darzu): Consider having a "NonsyncableComponentDef" or "NonupdatableComponentDef" that
-//  can take constructor args but can't be synced and throws an error if u use EM.set twice since
-//  it can't update. See "NonUpdatableComponentDef" branch for one attempt, but i ran into type
-//  issues i couldn't fix.
-
 export interface ComponentDef<
   N extends string = string,
   P = any,
   CArgs extends any[] = any,
   UArgs extends any[] = any
 > {
-  _brand: "componentDef"; // TODO(@darzu): remove once ResourceDef & ComponentDef are incompatible
+  _brand: "componentDef";
   updatable: boolean;
   readonly name: N;
   construct: (...args: CArgs) => P;
   update: (p: P, ...args: UArgs) => P;
-  // make: () => P;
-  // update: (p: P, ...args: Pargs) => P;
   readonly id: CompId;
   isOn: <E extends Entity>(e: E) => e is E & { [K in N]: P };
 }

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -353,6 +353,10 @@ export class EntityManager {
     serialize: (obj: P, buf: Serializer) => void,
     deserialize: (obj: P, buf: Deserializer) => void
   ) {
+    assert(
+      def.updatable,
+      `Can't attach serializers to non-updatable component '${def.name}'`
+    );
     this.serializers.set(def.id, { serialize, deserialize });
   }
 
@@ -387,6 +391,10 @@ export class EntityManager {
     if (buf.dummy) {
       component = {} as any;
     } else if (!entity) {
+      assert(
+        def.updatable,
+        `Trying to deserialize into non-updatable component '${def.name}'!`
+      );
       component = this.addComponent(id, def);
     } else {
       component = entity[def.name];

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -462,7 +462,7 @@ export class EntityManager {
   public addComponent<N extends string, P, PArgs extends any[]>(
     id: number,
     def: _ComponentDef<N, P, PArgs>,
-    ...args: PArgs // TODO(@darzu): REFACTOR. Types aren't right yet
+    ...args: PArgs
   ): P {
     this.checkComponent(def);
     if (id === 0) throw `hey, use addResource!`;
@@ -475,8 +475,6 @@ export class EntityManager {
     }
     if (def.name in e)
       throw `double defining component ${def.name} on ${e.id}!`;
-    // TODO(@darzu): REFACTOR:
-    // TODO(@darzu): HACK. Types aren't right..
     let c: P;
     if (def.updatable) {
       c = def.construct();
@@ -485,8 +483,6 @@ export class EntityManager {
       c = def.construct(...args);
     }
 
-    // let c = def.make();
-    // c = def.update(c, ...args);
     (e as any)[def.name] = c;
 
     // update query caches
@@ -567,14 +563,15 @@ export class EntityManager {
     ...args: PArgs
   ): asserts e is EntityW<[_ComponentDef<N, P, PArgs>]> {
     const alreadyHas = def.name in e;
-    // assert(!alreadyHas, `${e.id} already has ${def.name}`);
     if (!alreadyHas) {
       // TODO(@darzu): REFACTOR. types aren't right yet
       this.addComponent(e.id, def, ...args);
     } else {
-      // TODO(@darzu): REFACTOR:
-      // assert(def.updatable, `Cannot `
-      // def.update
+      assert(
+        def.updatable,
+        `Trying to double set non-updatable component '${def.name}' on '${e.id}'`
+      );
+      (e as any)[def.name] = def.update((e as any)[def.name], ...args);
     }
   }
 

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -10,6 +10,7 @@ import { Serializer, Deserializer } from "../utils/serialize.js";
 import {
   assert,
   assertDbg,
+  dbgLogOnce,
   dbgOnce,
   getCallStack,
   hashCode,
@@ -560,6 +561,8 @@ export class EntityManager {
         def.updatable,
         `Trying to double set non-updatable component '${def.name}' on '${e.id}'`
       );
+      // if (def.name === "authority") throw new Error(`double-set authority`);
+      // dbgLogOnce(`double-set: ${e.id}.${def.name}`);
       (e as any)[def.name] = def.update((e as any)[def.name], ...args);
     }
   }

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -183,6 +183,7 @@ type ESetId<DS extends EDefId<number, any>[]> = {
     : never;
 };
 
+// TODO(@darzu): don't love these...
 export type EDef<CS extends ComponentDef[]> = readonly [...CS];
 export type ESet<DS extends EDef<any>[]> = {
   [K in keyof DS]: DS[K] extends EDef<infer CS> ? EntityW<CS, number> : never;
@@ -565,9 +566,19 @@ export class EntityManager {
 
   public setOnce<N extends string, P, PArgs extends any[]>(
     e: Entity,
+    def: UpdatableComponentDef<N, P, PArgs>,
+    ...args: PArgs
+  ): asserts e is EntityW<[UpdatableComponentDef<N, P, PArgs>]>;
+  public setOnce<N extends string, P, PArgs extends any[]>(
+    e: Entity,
     def: NonupdatableComponentDef<N, P, PArgs>,
     ...args: PArgs
-  ): asserts e is EntityW<[NonupdatableComponentDef<N, P, PArgs>]> {
+  ): asserts e is EntityW<[NonupdatableComponentDef<N, P, PArgs>]>;
+  public setOnce<N extends string, P, PArgs extends any[]>(
+    e: Entity,
+    def: _ComponentDef<N, P, PArgs>,
+    ...args: PArgs
+  ): asserts e is EntityW<[_ComponentDef<N, P, PArgs>]> {
     const alreadyHas = def.name in e;
     if (!alreadyHas) {
       this.addComponent(e.id, def, ...args);

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -556,7 +556,6 @@ export class EntityManager {
   ): asserts e is EntityW<[_ComponentDef<N, P, PArgs>]> {
     const alreadyHas = def.name in e;
     if (!alreadyHas) {
-      // TODO(@darzu): REFACTOR. types aren't right yet
       this.addComponent(e.id, def, ...args);
     } else {
       assert(

--- a/src/ecs/entity-manager.ts
+++ b/src/ecs/entity-manager.ts
@@ -547,17 +547,17 @@ export class EntityManager {
   // TODO(@darzu): do we want to make this the standard way we do ensureComponent and addComponent ?
   // TODO(@darzu): rename to "set" and have "maybeSet" w/ a thunk as a way to short circuit unnecessary init?
   //      and maybe "strictSet" as the version that throws if it exists (renamed from "addComponent")
-  public ensureComponentOn<N extends string, P, PArgs extends any[]>(
+  public set<N extends string, P, PArgs extends any[]>(
     e: Entity,
     def: UpdatableComponentDef<N, P, PArgs>,
     ...args: PArgs
   ): asserts e is EntityW<[UpdatableComponentDef<N, P, PArgs>]>;
-  public ensureComponentOn<N extends string, P, PArgs extends any[]>(
+  public set<N extends string, P, PArgs extends any[]>(
     e: Entity,
     def: NonupdatableComponentDef<N, P, PArgs>,
     ...args: PArgs
   ): asserts e is EntityW<[NonupdatableComponentDef<N, P, PArgs>]>;
-  public ensureComponentOn<N extends string, P, PArgs extends any[]>(
+  public set<N extends string, P, PArgs extends any[]>(
     e: Entity,
     def: _ComponentDef<N, P, PArgs>,
     ...args: PArgs

--- a/src/ecs/lifetime.ts
+++ b/src/ecs/lifetime.ts
@@ -4,10 +4,15 @@ import { AuthorityDef, MeDef } from "../net/components.js";
 import { TimeDef } from "../time/time.js";
 import { Phase } from "./sys-phase.js";
 
-export const LifetimeDef = EM.defineComponent(
+export const LifetimeDef = EM.defineComponent2(
   "lifetime",
-  (ms: number = 1000) => {
-    return { startMs: ms, ms: ms };
+  () => {
+    return { startMs: 1000, ms: 1000 };
+  },
+  (p, ms: number = 1000) => {
+    p.startMs = ms;
+    p.ms = ms;
+    return p;
   }
 );
 export type Lifetime = Component<typeof LifetimeDef>;

--- a/src/ecs/lifetime.ts
+++ b/src/ecs/lifetime.ts
@@ -29,7 +29,7 @@ EM.addSystem(
       o.lifetime.ms -= res.time.dt;
       if (o.lifetime.ms < 0) {
         // TODO(@darzu): dead or deleted?
-        EM.addComponent(o.id, DeadDef);
+        EM.set(o, DeadDef);
         // TODO(@darzu): note needed?
         // EM.addComponent(o.id, DeletedDef);
       }

--- a/src/ecs/lifetime.ts
+++ b/src/ecs/lifetime.ts
@@ -4,7 +4,7 @@ import { AuthorityDef, MeDef } from "../net/components.js";
 import { TimeDef } from "../time/time.js";
 import { Phase } from "./sys-phase.js";
 
-export const LifetimeDef = EM.defineComponent2(
+export const LifetimeDef = EM.defineComponent(
   "lifetime",
   () => {
     return { startMs: 1000, ms: 1000 };

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,7 +7,7 @@ export const DBG_ASSERT = true;
 
 // Network
 export const DONT_SMOOTH_WORLD_FRAME = true; // TODO(@darzu): PERF HACK for single player
-export const ENABLE_NET = false;
+export const ENABLE_NET = true;
 export const VERBOSE_NET_LOG = false;
 
 // Ocean

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,7 +7,7 @@ export const DBG_ASSERT = true;
 
 // Network
 export const DONT_SMOOTH_WORLD_FRAME = true; // TODO(@darzu): PERF HACK for single player
-export const ENABLE_NET = true;
+export const ENABLE_NET = false;
 export const VERBOSE_NET_LOG = false;
 
 // Ocean

--- a/src/grass/game-grass.ts
+++ b/src/grass/game-grass.ts
@@ -178,19 +178,15 @@ export async function initGrassGame(hosting: boolean) {
 
   // Sun
   const sunlight = EM.new();
-  EM.ensureComponentOn(sunlight, PointLightDef);
+  EM.set(sunlight, PointLightDef);
   // sunlight.pointLight.constant = 1.0;
   sunlight.pointLight.constant = 1.0;
   sunlight.pointLight.linear = 0.0;
   sunlight.pointLight.quadratic = 0.0;
   vec3.copy(sunlight.pointLight.ambient, [0.2, 0.2, 0.2]);
   vec3.copy(sunlight.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sunlight, PositionDef, V(50, 300, 10));
-  EM.ensureComponentOn(
-    sunlight,
-    RenderableConstructDef,
-    res.gg_meshes.ball.proto
-  );
+  EM.set(sunlight, PositionDef, V(50, 300, 10));
+  EM.set(sunlight, RenderableConstructDef, res.gg_meshes.ball.proto);
 
   // score
   const score = EM.addResource(ScoreDef);
@@ -199,16 +195,9 @@ export async function initGrassGame(hosting: boolean) {
   const SKY_HALFSIZE = 1000;
   const domeMesh = makeDome(16, 8, SKY_HALFSIZE);
   const sky = EM.new();
-  EM.ensureComponentOn(sky, PositionDef, V(0, -100, 0));
+  EM.set(sky, PositionDef, V(0, -100, 0));
   const skyMesh = domeMesh;
-  EM.ensureComponentOn(
-    sky,
-    RenderableConstructDef,
-    skyMesh,
-    undefined,
-    undefined,
-    SKY_MASK
-  );
+  EM.set(sky, RenderableConstructDef, skyMesh, undefined, undefined, SKY_MASK);
 
   // ground
   const ground = EM.new();
@@ -217,15 +206,11 @@ export async function initGrassGame(hosting: boolean) {
     groundMesh,
     mat4.fromScaling(V(WORLD_HEIGHT, 1.0, WORLD_WIDTH))
   );
-  EM.ensureComponentOn(ground, RenderableConstructDef, groundMesh);
-  EM.ensureComponentOn(ground, ColorDef, ENDESGA16.darkGreen);
+  EM.set(ground, RenderableConstructDef, groundMesh);
+  EM.set(ground, ColorDef, ENDESGA16.darkGreen);
   // EM.set(ground, ColorDef, ENDESGA16.darkGreen);
   // EM.ensureComponentOn(p, ColorDef, [0.2, 0.3, 0.2]);
-  EM.ensureComponentOn(
-    ground,
-    PositionDef,
-    V(-WORLD_HEIGHT * 0.5, -1.1, -WORLD_WIDTH * 0.5)
-  );
+  EM.set(ground, PositionDef, V(-WORLD_HEIGHT * 0.5, -1.1, -WORLD_WIDTH * 0.5));
   // EM.ensureComponentOn(plane, PositionDef, [0, -5, 0]);
 
   // grass
@@ -283,7 +268,7 @@ export async function initGrassGame(hosting: boolean) {
   };
   const grMesh = createGrassTile(tileOpts);
   const gr = EM.new();
-  EM.ensureComponentOn(
+  EM.set(
     gr,
     RenderableConstructDef,
     grMesh,
@@ -294,8 +279,8 @@ export async function initGrassGame(hosting: boolean) {
     grassPoolPtr
     // true
   );
-  EM.ensureComponentOn(gr, ColorDef, randColor());
-  EM.ensureComponentOn(gr, PositionDef);
+  EM.set(gr, ColorDef, randColor());
+  EM.set(gr, PositionDef);
 
   // set
   const ts = await Promise.all([
@@ -341,13 +326,13 @@ export async function initGrassGame(hosting: boolean) {
     g.controllable.sprintMul = 15;
     const sphereMesh = cloneMesh(res.gg_meshes.ball.mesh);
     const visible = false;
-    EM.ensureComponentOn(g, RenderableConstructDef, sphereMesh, visible);
-    EM.ensureComponentOn(g, ColorDef, V(0.1, 0.1, 0.1));
+    EM.set(g, RenderableConstructDef, sphereMesh, visible);
+    EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
     // EM.ensureComponentOn(g, PositionDef, V(0, 0, 0));
     // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-    EM.ensureComponentOn(g, WorldFrameDef);
+    EM.set(g, WorldFrameDef);
     // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-    EM.ensureComponentOn(g, ColliderDef, {
+    EM.set(g, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: res.gg_meshes.ball.aabb,
@@ -708,13 +693,9 @@ export async function initGrassGame(hosting: boolean) {
   // world gizmo
   const gizmoMesh = await GizmoMesh.gameMesh();
   const worldGizmo = EM.new();
-  EM.ensureComponentOn(
-    worldGizmo,
-    PositionDef,
-    V(-WORLD_HEIGHT / 2, 0, -WORLD_WIDTH / 2)
-  );
-  EM.ensureComponentOn(worldGizmo, ScaleDef, V(100, 100, 100));
-  EM.ensureComponentOn(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
+  EM.set(worldGizmo, PositionDef, V(-WORLD_HEIGHT / 2, 0, -WORLD_WIDTH / 2));
+  EM.set(worldGizmo, ScaleDef, V(100, 100, 100));
+  EM.set(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
 
   // debugging createGraph3D
   let data: vec3[][] = [];
@@ -730,19 +711,19 @@ export async function initGrassGame(hosting: boolean) {
 async function createPlayer() {
   const { gg_meshes, me } = await EM.whenResources(grassGameMeshesDef, MeDef);
   const p = EM.new();
-  EM.ensureComponentOn(p, ControllableDef);
+  EM.set(p, ControllableDef);
   p.controllable.modes.canFall = false;
   p.controllable.modes.canJump = false;
   // g.controllable.modes.canYaw = true;
   // g.controllable.modes.canPitch = true;
-  EM.ensureComponentOn(p, CameraFollowDef, 1);
+  EM.set(p, CameraFollowDef, 1);
   // setCameraFollowPosition(p, "firstPerson");
   // setCameraFollowPosition(p, "thirdPerson");
-  EM.ensureComponentOn(p, PositionDef);
-  EM.ensureComponentOn(p, RotationDef);
+  EM.set(p, PositionDef);
+  EM.set(p, RotationDef);
   // quat.rotateY(g.rotation, quat.IDENTITY, (-5 * Math.PI) / 8);
   // quat.rotateX(g.cameraFollow.rotationOffset, quat.IDENTITY, -Math.PI / 8);
-  EM.ensureComponentOn(p, LinearVelocityDef);
+  EM.set(p, LinearVelocityDef);
 
   vec3.copy(p.position, [0, 1, -1.2]);
   quat.setAxisAngle([0.0, -1.0, 0.0], 1.62, p.rotation);
@@ -751,13 +732,13 @@ async function createPlayer() {
   p.controllable.sprintMul = 10;
   const sphereMesh = cloneMesh(gg_meshes.ball.mesh);
   const visible = true;
-  EM.ensureComponentOn(p, RenderableConstructDef, sphereMesh, visible);
-  EM.ensureComponentOn(p, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(p, PositionDef, V(0, 0, 0));
+  EM.set(p, RenderableConstructDef, sphereMesh, visible);
+  EM.set(p, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(p, PositionDef, V(0, 0, 0));
   // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-  EM.ensureComponentOn(p, WorldFrameDef);
+  EM.set(p, WorldFrameDef);
   // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-  EM.ensureComponentOn(p, ColliderDef, {
+  EM.set(p, ColliderDef, {
     shape: "AABB",
     solid: true,
     aabb: gg_meshes.ball.aabb,
@@ -770,8 +751,8 @@ async function createPlayer() {
   p.cameraFollow.pitchOffset = -0.593;
 
   EM.ensureResource(LocalHsPlayerDef, p.id);
-  EM.ensureComponentOn(p, HsPlayerDef);
-  EM.ensureComponentOn(p, AuthorityDef, me.pid);
-  EM.ensureComponentOn(p, PhysicsParentDef);
+  EM.set(p, HsPlayerDef);
+  EM.set(p, AuthorityDef, me.pid);
+  EM.set(p, PhysicsParentDef);
   return p;
 }

--- a/src/grass/game-grass.ts
+++ b/src/grass/game-grass.ts
@@ -209,9 +209,9 @@ export async function initGrassGame(hosting: boolean) {
   EM.set(ground, RenderableConstructDef, groundMesh);
   EM.set(ground, ColorDef, ENDESGA16.darkGreen);
   // EM.set(ground, ColorDef, ENDESGA16.darkGreen);
-  // EM.ensureComponentOn(p, ColorDef, [0.2, 0.3, 0.2]);
+  // EM.set(p, ColorDef, [0.2, 0.3, 0.2]);
   EM.set(ground, PositionDef, V(-WORLD_HEIGHT * 0.5, -1.1, -WORLD_WIDTH * 0.5));
-  // EM.ensureComponentOn(plane, PositionDef, [0, -5, 0]);
+  // EM.set(plane, PositionDef, [0, -5, 0]);
 
   // grass
   const lod1: GrassTilesetOpts = {
@@ -328,10 +328,10 @@ export async function initGrassGame(hosting: boolean) {
     const visible = false;
     EM.set(g, RenderableConstructDef, sphereMesh, visible);
     EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
-    // EM.ensureComponentOn(g, PositionDef, V(0, 0, 0));
-    // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+    // EM.set(g, PositionDef, V(0, 0, 0));
+    // EM.set(b2, PositionDef, [0, 0, -1.2]);
     EM.set(g, WorldFrameDef);
-    // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+    // EM.set(b2, PhysicsParentDef, g.id);
     EM.set(g, ColliderDef, {
       shape: "AABB",
       solid: false,
@@ -735,9 +735,9 @@ async function createPlayer() {
   EM.set(p, RenderableConstructDef, sphereMesh, visible);
   EM.set(p, ColorDef, V(0.1, 0.1, 0.1));
   EM.set(p, PositionDef, V(0, 0, 0));
-  // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+  // EM.set(b2, PositionDef, [0, 0, -1.2]);
   EM.set(p, WorldFrameDef);
-  // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+  // EM.set(b2, PhysicsParentDef, g.id);
   EM.set(p, ColliderDef, {
     shape: "AABB",
     solid: true,

--- a/src/grass/grass.ts
+++ b/src/grass/grass.ts
@@ -192,8 +192,8 @@ export async function createGrassTileset(
       // console.log(`(${xi}, ${zi})`);
       // TODO(@darzu): USE INSTANCING
       const tile = EM.new();
-      EM.ensureComponentOn(tile, PositionDef, V(x, 0, z));
-      EM.ensureComponentOn(
+      EM.set(tile, PositionDef, V(x, 0, z));
+      EM.set(
         tile,
         RenderableConstructDef,
         tileProto,
@@ -203,7 +203,7 @@ export async function createGrassTileset(
         undefined,
         grassPoolPtr
       );
-      EM.ensureComponentOn(tile, ColorDef, randColor());
+      EM.set(tile, ColorDef, randColor());
       // mat4.translate(tile.transform, tile.transform, [x, 0, z]);
       // builder.updateUniform(tile);
 

--- a/src/grass/std-grass.ts
+++ b/src/grass/std-grass.ts
@@ -142,7 +142,9 @@ function computeGrassVertsData(
   return tempVertsData;
 }
 
-function createEmptyGrassUniTS(): GrassUniTS {
+export function computeGrassUniData(m: Mesh): GrassUniTS {
+  // TODO(@darzu): change
+  // const { min, max } = getAABBFromMesh(m);
   const uni: GrassUniTS = {
     transform: mat4.create(),
     // aabbMin: min,
@@ -154,19 +156,15 @@ function createEmptyGrassUniTS(): GrassUniTS {
   return uni;
 }
 
-export function updateGrassUniData(u: GrassUniTS, m: Mesh): GrassUniTS {
-  // TODO(@darzu): change
-  // const { min, max } = getAABBFromMesh(m);
-  return u;
-}
-
-export const RenderDataGrassDef = EM.defineComponent(
+export const RenderDataGrassDef = EM.defineNonupdatableComponent(
   "renderDataGrass",
-  createEmptyGrassUniTS,
-  updateGrassUniData
+  (r: GrassUniTS) => r
 );
 export const grassPoolPtr = CY.createMeshPool("grassPool", {
   computeVertsData: computeGrassVertsData,
+  // TODO(@darzu): per-mesh unis should maybe be optional? I don't think
+  //     the grass needs them
+  computeUniData: computeGrassUniData,
   vertsStruct: GrassVertStruct,
   unisStruct: GrassUniStruct,
   maxMeshes: MAX_GRASS_MESHES,

--- a/src/grass/std-grass.ts
+++ b/src/grass/std-grass.ts
@@ -142,9 +142,7 @@ function computeGrassVertsData(
   return tempVertsData;
 }
 
-export function computeGrassUniData(m: Mesh): GrassUniTS {
-  // TODO(@darzu): change
-  // const { min, max } = getAABBFromMesh(m);
+function createEmptyGrassUniTS(): GrassUniTS {
   const uni: GrassUniTS = {
     transform: mat4.create(),
     // aabbMin: min,
@@ -156,15 +154,19 @@ export function computeGrassUniData(m: Mesh): GrassUniTS {
   return uni;
 }
 
-export const RenderDataGrassDef = EM.defineComponent(
+export function updateGrassUniData(u: GrassUniTS, m: Mesh): GrassUniTS {
+  // TODO(@darzu): change
+  // const { min, max } = getAABBFromMesh(m);
+  return u;
+}
+
+export const RenderDataGrassDef = EM.defineComponent2(
   "renderDataGrass",
-  (r: GrassUniTS) => r
+  createEmptyGrassUniTS,
+  updateGrassUniData
 );
 export const grassPoolPtr = CY.createMeshPool("grassPool", {
   computeVertsData: computeGrassVertsData,
-  // TODO(@darzu): per-mesh unis should maybe be optional? I don't think
-  //     the grass needs them
-  computeUniData: computeGrassUniData,
   vertsStruct: GrassVertStruct,
   unisStruct: GrassUniStruct,
   maxMeshes: MAX_GRASS_MESHES,

--- a/src/grass/std-grass.ts
+++ b/src/grass/std-grass.ts
@@ -160,7 +160,7 @@ export function updateGrassUniData(u: GrassUniTS, m: Mesh): GrassUniTS {
   return u;
 }
 
-export const RenderDataGrassDef = EM.defineComponent2(
+export const RenderDataGrassDef = EM.defineComponent(
   "renderDataGrass",
   createEmptyGrassUniTS,
   updateGrassUniData

--- a/src/gui/button.ts
+++ b/src/gui/button.ts
@@ -37,20 +37,14 @@ export interface ButtonColors {
   down: vec3;
 }
 
-export const ButtonDef = EM.defineComponent(
+export const ButtonDef = EM.defineNonupdatableComponent(
   "button",
-  () => ({
-    key: "",
-    data: undefined as number | undefined,
-    colors: undefined as ButtonColors | undefined,
-  }),
-  (p, key: string, data?: number, colors?: ButtonColors) =>
-    Object.assign(p, {
-      key,
-      // TODO(@darzu): better way to do this? Maybe typed "known" buttons ala assets
-      data,
-      colors,
-    })
+  (key: string, data?: number, colors?: ButtonColors) => ({
+    key,
+    // TODO(@darzu): better way to do this? Maybe typed "known" buttons ala assets
+    data,
+    colors,
+  })
 );
 
 // TODO(@darzu): GUIStateDef ?

--- a/src/gui/button.ts
+++ b/src/gui/button.ts
@@ -37,7 +37,7 @@ export interface ButtonColors {
   down: vec3;
 }
 
-export const ButtonDef = EM.defineComponent2(
+export const ButtonDef = EM.defineComponent(
   "button",
   () => ({
     key: "",

--- a/src/gui/button.ts
+++ b/src/gui/button.ts
@@ -37,14 +37,20 @@ export interface ButtonColors {
   down: vec3;
 }
 
-export const ButtonDef = EM.defineComponent(
+export const ButtonDef = EM.defineComponent2(
   "button",
-  (key: string, data?: number, colors?: ButtonColors) => ({
-    key,
-    // TODO(@darzu): better way to do this? Maybe typed "known" buttons ala assets
-    data,
-    colors,
-  })
+  () => ({
+    key: "",
+    data: undefined as number | undefined,
+    colors: undefined as ButtonColors | undefined,
+  }),
+  (p, key: string, data?: number, colors?: ButtonColors) =>
+    Object.assign(p, {
+      key,
+      // TODO(@darzu): better way to do this? Maybe typed "known" buttons ala assets
+      data,
+      colors,
+    })
 );
 
 // TODO(@darzu): GUIStateDef ?

--- a/src/gui/cursor.ts
+++ b/src/gui/cursor.ts
@@ -30,7 +30,7 @@ export const GlobalCursor3dDef = EM.defineResource("globalCursor3d", () => {
   };
 });
 
-export const Cursor3dDef = EM.defineComponent2(
+export const Cursor3dDef = EM.defineComponent(
   "cursor3d",
   () => ({
     hitId: 0,

--- a/src/gui/cursor.ts
+++ b/src/gui/cursor.ts
@@ -30,14 +30,10 @@ export const GlobalCursor3dDef = EM.defineResource("globalCursor3d", () => {
   };
 });
 
-export const Cursor3dDef = EM.defineComponent(
-  "cursor3d",
-  () => ({
-    hitId: 0,
-    maxDistance: 100,
-  }),
-  (p) => p
-);
+export const Cursor3dDef = EM.defineComponent("cursor3d", () => ({
+  hitId: 0,
+  maxDistance: 100,
+}));
 
 EM.addLazyInit([BallMesh.def], [GlobalCursor3dDef], async (res) => {
   {

--- a/src/gui/cursor.ts
+++ b/src/gui/cursor.ts
@@ -30,10 +30,14 @@ export const GlobalCursor3dDef = EM.defineResource("globalCursor3d", () => {
   };
 });
 
-export const Cursor3dDef = EM.defineComponent("cursor3d", () => ({
-  hitId: 0,
-  maxDistance: 100,
-}));
+export const Cursor3dDef = EM.defineComponent2(
+  "cursor3d",
+  () => ({
+    hitId: 0,
+    maxDistance: 100,
+  }),
+  (p) => p
+);
 
 EM.addLazyInit([BallMesh.def], [GlobalCursor3dDef], async (res) => {
   {

--- a/src/gui/cursor.ts
+++ b/src/gui/cursor.ts
@@ -39,14 +39,13 @@ EM.addLazyInit([BallMesh.def], [GlobalCursor3dDef], async (res) => {
   {
     console.log(`init global cursor`);
     const cursor = EM.new();
-    const id = cursor.id;
-    EM.addComponent(id, Cursor3dDef);
-    EM.addComponent(id, PositionDef);
+    EM.set(cursor, Cursor3dDef);
+    EM.set(cursor, PositionDef);
     // TODO(@darzu): support wireframe
     // const wireframe: Mesh = { ...res.allMeshes.ball.mesh, tri: [] };
     const wireframe: Mesh = res.mesh_ball.mesh;
-    EM.addComponent(id, RenderableConstructDef, wireframe, false);
-    EM.addComponent(id, ColorDef, V(0, 1, 1));
+    EM.set(cursor, RenderableConstructDef, wireframe, false);
+    EM.set(cursor, ColorDef, V(0, 1, 1));
     const builtCursor = await EM.whenEntityHas(
       cursor,
       Cursor3dDef,

--- a/src/gui/game-font.ts
+++ b/src/gui/game-font.ts
@@ -123,7 +123,7 @@ export async function initFontEditor() {
   // panelMesh.colors[1] = [0.1, 0.1, 0.3];
   panelMesh.colors[0] = V(0.4, 0.4, 0.4);
   EM.set(panel, RenderableConstructDef, panelMesh);
-  // EM.ensureComponentOn(panel, ColorDef, [0.2, 0.3, 0.2]);
+  // EM.set(panel, ColorDef, [0.2, 0.3, 0.2]);
   EM.set(panel, PositionDef, V(0, 0, 0));
 
   if (DBG_3D) {

--- a/src/gui/game-font.ts
+++ b/src/gui/game-font.ts
@@ -64,13 +64,13 @@ export const UICursorDef = EM.defineResource(
 EM.addLazyInit([AllMeshesDef], [UICursorDef], ({ allMeshes }) => {
   // Cursor
   const cursor = EM.new();
-  EM.ensureComponentOn(cursor, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(cursor, PositionDef, V(0, 1.0, 0));
-  EM.ensureComponentOn(cursor, RenderableConstructDef, allMeshes.he_octo.proto);
+  EM.set(cursor, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(cursor, PositionDef, V(0, 1.0, 0));
+  EM.set(cursor, RenderableConstructDef, allMeshes.he_octo.proto);
   const cursorLocalAABB = copyAABB(createAABB(), allMeshes.he_octo.aabb);
   cursorLocalAABB.min[1] = -1;
   cursorLocalAABB.max[1] = 1;
-  EM.ensureComponentOn(cursor, ColliderDef, {
+  EM.set(cursor, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: cursorLocalAABB,
@@ -105,17 +105,12 @@ export async function initFontEditor() {
   ];
 
   const sunlight = EM.new();
-  EM.ensureComponentOn(sunlight, PointLightDef);
+  EM.set(sunlight, PointLightDef);
   sunlight.pointLight.constant = 1.0;
   vec3.copy(sunlight.pointLight.ambient, [0.8, 0.8, 0.8]);
-  EM.ensureComponentOn(sunlight, PositionDef, V(10, 100, 10));
+  EM.set(sunlight, PositionDef, V(10, 100, 10));
   // TODO(@darzu): weird, why does renderable need to be on here?
-  EM.ensureComponentOn(
-    sunlight,
-    RenderableConstructDef,
-    res.allMeshes.ball.proto,
-    false
-  );
+  EM.set(sunlight, RenderableConstructDef, res.allMeshes.ball.proto, false);
 
   const panel = EM.new();
   const panelMesh = makePlaneMesh(
@@ -127,13 +122,13 @@ export async function initFontEditor() {
   // panelMesh.colors[0] = [0.1, 0.3, 0.1];
   // panelMesh.colors[1] = [0.1, 0.1, 0.3];
   panelMesh.colors[0] = V(0.4, 0.4, 0.4);
-  EM.ensureComponentOn(panel, RenderableConstructDef, panelMesh);
+  EM.set(panel, RenderableConstructDef, panelMesh);
   // EM.ensureComponentOn(panel, ColorDef, [0.2, 0.3, 0.2]);
-  EM.ensureComponentOn(panel, PositionDef, V(0, 0, 0));
+  EM.set(panel, PositionDef, V(0, 0, 0));
 
   if (DBG_3D) {
     const g = createGhost();
-    EM.ensureComponentOn(g, RenderableConstructDef, res.allMeshes.ball.proto);
+    EM.set(g, RenderableConstructDef, res.allMeshes.ball.proto);
 
     // vec3.copy(g.position, [4.36,30.83,-1.53]);
     // quat.copy(g.rotation, [0.00,0.71,0.00,0.70]);
@@ -298,15 +293,15 @@ export async function initFontEditor() {
     polyBank.set(i, gmesh);
 
     const btn = EM.new();
-    EM.ensureComponentOn(btn, RenderableConstructDef, gmesh.proto);
-    EM.ensureComponentOn(btn, PositionDef, V(-24 + i * 2, 0.1, 12));
-    EM.ensureComponentOn(btn, ButtonDef, btnKey, i, {
+    EM.set(btn, RenderableConstructDef, gmesh.proto);
+    EM.set(btn, PositionDef, V(-24 + i * 2, 0.1, 12));
+    EM.set(btn, ButtonDef, btnKey, i, {
       default: ENDESGA16.lightGray,
       hover: ENDESGA16.darkGray,
       down: ENDESGA16.orange,
     });
-    EM.ensureComponentOn(btn, ColorDef);
-    EM.ensureComponentOn(btn, ColliderDef, {
+    EM.set(btn, ColorDef);
+    EM.set(btn, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: gmesh.aabb,

--- a/src/gui/mesh-editor.ts
+++ b/src/gui/mesh-editor.ts
@@ -38,12 +38,20 @@ import { GameMesh } from "../meshes/mesh-loader.js";
 
 // TODO(@darzu): do we need this ptr indirection? can't we just add/remove component? how does this interact
 //  with pools?
-const HEdgeDef = EM.defineComponent("hedge", (he: HEdge) => ({
-  he,
-}));
-const HVertDef = EM.defineComponent("hvert", (hv: HVert) => ({
-  hv,
-}));
+const HEdgeDef = EM.defineComponent2(
+  "hedge",
+  () => ({
+    he: undefined as any as HEdge,
+  }),
+  (p, he: HEdge) => Object.assign(p, { he })
+);
+const HVertDef = EM.defineComponent2(
+  "hvert",
+  () => ({
+    hv: undefined as any as HVert,
+  }),
+  (p, hv: HVert) => Object.assign(p, { hv })
+);
 
 type HEdgeWEnt = EntityW<
   [

--- a/src/gui/mesh-editor.ts
+++ b/src/gui/mesh-editor.ts
@@ -38,20 +38,12 @@ import { GameMesh } from "../meshes/mesh-loader.js";
 
 // TODO(@darzu): do we need this ptr indirection? can't we just add/remove component? how does this interact
 //  with pools?
-const HEdgeDef = EM.defineComponent(
-  "hedge",
-  () => ({
-    he: undefined as any as HEdge,
-  }),
-  (p, he: HEdge) => Object.assign(p, { he })
-);
-const HVertDef = EM.defineComponent(
-  "hvert",
-  () => ({
-    hv: undefined as any as HVert,
-  }),
-  (p, hv: HVert) => Object.assign(p, { hv })
-);
+const HEdgeDef = EM.defineNonupdatableComponent("hedge", (he: HEdge) => ({
+  he,
+}));
+const HVertDef = EM.defineNonupdatableComponent("hvert", (hv: HVert) => ({
+  hv,
+}));
 
 type HEdgeWEnt = EntityW<
   [

--- a/src/gui/mesh-editor.ts
+++ b/src/gui/mesh-editor.ts
@@ -38,14 +38,14 @@ import { GameMesh } from "../meshes/mesh-loader.js";
 
 // TODO(@darzu): do we need this ptr indirection? can't we just add/remove component? how does this interact
 //  with pools?
-const HEdgeDef = EM.defineComponent2(
+const HEdgeDef = EM.defineComponent(
   "hedge",
   () => ({
     he: undefined as any as HEdge,
   }),
   (p, he: HEdge) => Object.assign(p, { he })
 );
-const HVertDef = EM.defineComponent2(
+const HVertDef = EM.defineComponent(
   "hvert",
   () => ({
     hv: undefined as any as HVert,

--- a/src/gui/mesh-editor.ts
+++ b/src/gui/mesh-editor.ts
@@ -157,7 +157,7 @@ async function createMeshEditor() {
       );
     } else {
       const hpEnt_ = EM.new();
-      EM.ensureComponentOn(
+      EM.set(
         hpEnt_,
         RenderableConstructDef,
         handle,
@@ -167,9 +167,9 @@ async function createMeshEditor() {
         meshPoolPtr,
         false
       );
-      EM.ensureComponentOn(hpEnt_, PositionDef, V(0, 0.1, 0));
+      EM.set(hpEnt_, PositionDef, V(0, 0.1, 0));
       // TODO(@darzu): make scale configurable
-      EM.ensureComponentOn(hpEnt_, ScaleDef, V(5, 5, 5));
+      EM.set(hpEnt_, ScaleDef, V(5, 5, 5));
       const hpEnt = await EM.whenEntityHas(
         hpEnt_,
         RenderableDef,
@@ -206,12 +206,12 @@ async function createMeshEditor() {
 
   function _createGlyph(gm: GameMesh) {
     const glyph_ = EM.new();
-    EM.ensureComponentOn(glyph_, RenderableConstructDef, gm.proto, false);
-    EM.ensureComponentOn(glyph_, ColorDef);
-    EM.ensureComponentOn(glyph_, PositionDef);
-    EM.ensureComponentOn(glyph_, RotationDef, quat.create());
-    EM.ensureComponentOn(glyph_, WidgetDef);
-    EM.ensureComponentOn(glyph_, ColliderDef, {
+    EM.set(glyph_, RenderableConstructDef, gm.proto, false);
+    EM.set(glyph_, ColorDef);
+    EM.set(glyph_, PositionDef);
+    EM.set(glyph_, RotationDef, quat.create());
+    EM.set(glyph_, WidgetDef);
+    EM.set(glyph_, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: gm.aabb,
@@ -226,8 +226,8 @@ async function createMeshEditor() {
     if (!vertGlyphPool[idx]) {
       // create if missing
       const glyph_ = _createGlyph(allMeshes.he_octo);
-      EM.ensureComponentOn(glyph_, HVertDef, hv);
-      EM.ensureComponentOn(glyph_, ButtonDef, "glyph-vert");
+      EM.set(glyph_, HVertDef, hv);
+      EM.set(glyph_, ButtonDef, "glyph-vert");
       const glyph = await EM.whenEntityHas(
         glyph_,
         HVertDef,
@@ -268,8 +268,8 @@ async function createMeshEditor() {
     if (!hedgeGlyphPool[idx]) {
       // create if missing
       const glyph_ = _createGlyph(allMeshes.he_quad);
-      EM.ensureComponentOn(glyph_, HEdgeDef, he);
-      EM.ensureComponentOn(glyph_, ButtonDef, "glyph-hedge");
+      EM.set(glyph_, HEdgeDef, he);
+      EM.set(glyph_, ButtonDef, "glyph-hedge");
       const glyph = await EM.whenEntityHas(
         glyph_,
         WidgetDef,

--- a/src/gui/path-editor.ts
+++ b/src/gui/path-editor.ts
@@ -30,9 +30,16 @@ import { WidgetDef, WidgetLayerDef } from "./widgets.js";
 import { meshPoolPtr } from "../render/pipelines/std-scene.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-const HLineDef = EM.defineComponent("hline", (hl: HLine) => ({
-  hl,
-}));
+const HLineDef = EM.defineComponent2(
+  "hline",
+  () => ({
+    hl: undefined as any as HLine,
+  }),
+  (p, hl: HLine) =>
+    Object.assign(p, {
+      hl,
+    })
+);
 
 // TODO(@darzu): terrible name
 type HLineEnt = EntityW<

--- a/src/gui/path-editor.ts
+++ b/src/gui/path-editor.ts
@@ -146,7 +146,7 @@ async function createPathEditor() {
       );
       EM.set(hpEnt_, PositionDef, V(0, 0.1, 0));
       // TODO(@darzu): make scale configurable
-      // EM.ensureComponentOn(hpEnt_, ScaleDef, [5, 5, 5]);
+      // EM.set(hpEnt_, ScaleDef, [5, 5, 5]);
       const hpEnt = await EM.whenEntityHas(
         hpEnt_,
         RenderableDef,

--- a/src/gui/path-editor.ts
+++ b/src/gui/path-editor.ts
@@ -30,7 +30,7 @@ import { WidgetDef, WidgetLayerDef } from "./widgets.js";
 import { meshPoolPtr } from "../render/pipelines/std-scene.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-const HLineDef = EM.defineComponent2(
+const HLineDef = EM.defineComponent(
   "hline",
   () => ({
     hl: undefined as any as HLine,

--- a/src/gui/path-editor.ts
+++ b/src/gui/path-editor.ts
@@ -133,7 +133,7 @@ async function createPathEditor() {
       };
 
       const hpEnt_ = EM.new();
-      EM.ensureComponentOn(
+      EM.set(
         hpEnt_,
         RenderableConstructDef,
         res.outMesh,
@@ -144,7 +144,7 @@ async function createPathEditor() {
         false,
         reserve
       );
-      EM.ensureComponentOn(hpEnt_, PositionDef, V(0, 0.1, 0));
+      EM.set(hpEnt_, PositionDef, V(0, 0.1, 0));
       // TODO(@darzu): make scale configurable
       // EM.ensureComponentOn(hpEnt_, ScaleDef, [5, 5, 5]);
       const hpEnt = await EM.whenEntityHas(
@@ -190,12 +190,12 @@ async function createPathEditor() {
   function _createGlyph(gm: GameMesh) {
     // TODO(@darzu): de-duplicate
     const glyph_ = EM.new();
-    EM.ensureComponentOn(glyph_, RenderableConstructDef, gm.proto, false);
-    EM.ensureComponentOn(glyph_, ColorDef);
-    EM.ensureComponentOn(glyph_, PositionDef);
-    EM.ensureComponentOn(glyph_, RotationDef, quat.create());
-    EM.ensureComponentOn(glyph_, WidgetDef);
-    EM.ensureComponentOn(glyph_, ColliderDef, {
+    EM.set(glyph_, RenderableConstructDef, gm.proto, false);
+    EM.set(glyph_, ColorDef);
+    EM.set(glyph_, PositionDef);
+    EM.set(glyph_, RotationDef, quat.create());
+    EM.set(glyph_, WidgetDef);
+    EM.set(glyph_, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: gm.aabb,
@@ -211,8 +211,8 @@ async function createPathEditor() {
     if (!glyphPool[idx]) {
       // create if missing
       const glyph_ = _createGlyph(allMeshes.he_octo);
-      EM.ensureComponentOn(glyph_, HLineDef, hl);
-      EM.ensureComponentOn(glyph_, ButtonDef, "glyph-vert");
+      EM.set(glyph_, HLineDef, hl);
+      EM.set(glyph_, ButtonDef, "glyph-vert");
       const glyph = await EM.whenEntityHas(
         glyph_,
         HLineDef,
@@ -419,19 +419,15 @@ export async function lineStuff() {
   const gmesh = gameMeshFromMesh(extMesh, renderer.renderer);
 
   const extEnt = EM.new();
-  EM.ensureComponentOn(extEnt, RenderableConstructDef, gmesh.proto);
-  EM.ensureComponentOn(extEnt, PositionDef, V(0, 0.5, 0));
+  EM.set(extEnt, RenderableConstructDef, gmesh.proto);
+  EM.set(extEnt, PositionDef, V(0, 0.5, 0));
 
   for (let ln of lns) {
     const vertGlyph = EM.new();
-    EM.ensureComponentOn(
-      vertGlyph,
-      RenderableConstructDef,
-      allMeshes.cube.proto
-    );
-    EM.ensureComponentOn(vertGlyph, PositionDef, vec3.clone(lnMesh.pos[ln.vi]));
-    EM.ensureComponentOn(vertGlyph, ColorDef, V(0.1, 0.2 + ln.vi * 0.1, 0.1));
-    EM.ensureComponentOn(vertGlyph, ScaleDef, V(0.2, 0.2, 0.2));
+    EM.set(vertGlyph, RenderableConstructDef, allMeshes.cube.proto);
+    EM.set(vertGlyph, PositionDef, vec3.clone(lnMesh.pos[ln.vi]));
+    EM.set(vertGlyph, ColorDef, V(0.1, 0.2 + ln.vi * 0.1, 0.1));
+    EM.set(vertGlyph, ScaleDef, V(0.2, 0.2, 0.2));
     vertGlyph.position[1] = 0.5;
   }
 

--- a/src/gui/path-editor.ts
+++ b/src/gui/path-editor.ts
@@ -30,16 +30,9 @@ import { WidgetDef, WidgetLayerDef } from "./widgets.js";
 import { meshPoolPtr } from "../render/pipelines/std-scene.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-const HLineDef = EM.defineComponent(
-  "hline",
-  () => ({
-    hl: undefined as any as HLine,
-  }),
-  (p, hl: HLine) =>
-    Object.assign(p, {
-      hl,
-    })
-);
+const HLineDef = EM.defineNonupdatableComponent("hline", (hl: HLine) => ({
+  hl,
+}));
 
 // TODO(@darzu): terrible name
 type HLineEnt = EntityW<

--- a/src/gui/widgets.ts
+++ b/src/gui/widgets.ts
@@ -20,11 +20,7 @@ import { Phase } from "../ecs/sys-phase.js";
 // adornments are: entities that are parented to an entity's mesh parts
 //    [ ] track changes via version number on the mesh data
 
-export const WidgetDef = EM.defineComponent(
-  "widget",
-  () => true,
-  (p) => p
-);
+export const WidgetDef = EM.defineComponent("widget", () => true);
 
 /*
 What's my data?

--- a/src/gui/widgets.ts
+++ b/src/gui/widgets.ts
@@ -20,7 +20,11 @@ import { Phase } from "../ecs/sys-phase.js";
 // adornments are: entities that are parented to an entity's mesh parts
 //    [ ] track changes via version number on the mesh data
 
-export const WidgetDef = EM.defineComponent("widget", () => true);
+export const WidgetDef = EM.defineComponent2(
+  "widget",
+  () => true,
+  (p) => p
+);
 
 /*
 What's my data?

--- a/src/gui/widgets.ts
+++ b/src/gui/widgets.ts
@@ -73,12 +73,12 @@ async function initDragBox(): Promise<EntityW<[typeof PositionDef]>> {
   // TODO(@darzu): dragbox should be part of some 2d gui abstraction thing
   const dragBox = EM.new();
   const dragBoxMesh = cloneMesh(unitCubeMesh.mesh);
-  EM.ensureComponentOn(dragBox, AlphaDef, 0.2);
-  EM.ensureComponentOn(dragBox, RenderableConstructDef, dragBoxMesh);
-  EM.ensureComponentOn(dragBox, PositionDef, V(0, 0.2, 0));
-  EM.ensureComponentOn(dragBox, ScaleDef, V(1, 1, 1));
-  EM.ensureComponentOn(dragBox, ColorDef, V(0.0, 120 / 255, 209 / 255));
-  EM.ensureComponentOn(dragBox, ColliderDef, {
+  EM.set(dragBox, AlphaDef, 0.2);
+  EM.set(dragBox, RenderableConstructDef, dragBoxMesh);
+  EM.set(dragBox, PositionDef, V(0, 0.2, 0));
+  EM.set(dragBox, ScaleDef, V(1, 1, 1));
+  EM.set(dragBox, ColorDef, V(0.0, 120 / 255, 209 / 255));
+  EM.set(dragBox, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: unitCubeMesh.aabb,

--- a/src/gui/widgets.ts
+++ b/src/gui/widgets.ts
@@ -20,7 +20,7 @@ import { Phase } from "../ecs/sys-phase.js";
 // adornments are: entities that are parented to an entity's mesh parts
 //    [ ] track changes via version number on the mesh data
 
-export const WidgetDef = EM.defineComponent2(
+export const WidgetDef = EM.defineComponent(
   "widget",
   () => true,
   (p) => p

--- a/src/hyperspace/darkstar.ts
+++ b/src/hyperspace/darkstar.ts
@@ -51,14 +51,10 @@ export const { DarkStarPropsDef, DarkStarLocalDef, createDarkStarNow } =
     buildResources: [AllMeshesDef],
     build: (star, res) => {
       vec3.copy(star.position, star.darkStarProps.pos);
-      EM.ensureComponentOn(
-        star,
-        RenderableConstructDef,
-        res.allMeshes.ball.proto
-      );
-      EM.ensureComponentOn(star, ScaleDef, V(100, 100, 100));
-      EM.ensureComponentOn(star, ColorDef, star.darkStarProps.color);
-      EM.ensureComponentOn(star, PointLightDef);
+      EM.set(star, RenderableConstructDef, res.allMeshes.ball.proto);
+      EM.set(star, ScaleDef, V(100, 100, 100));
+      EM.set(star, ColorDef, star.darkStarProps.color);
+      EM.set(star, PointLightDef);
       star.pointLight.constant = 1.0;
       vec3.copy(star.pointLight.ambient, star.color);
       vec3.scale(star.pointLight.ambient, 0.2, star.pointLight.ambient);

--- a/src/hyperspace/darkstar.ts
+++ b/src/hyperspace/darkstar.ts
@@ -19,17 +19,25 @@ export const STAR2_COLOR = V(0.3, 0.8, 0.6);
 export const { DarkStarPropsDef, DarkStarLocalDef, createDarkStarNow } =
   defineNetEntityHelper({
     name: "darkStar",
-    defaultProps: (
+    defaultProps: () => ({
+      pos: vec3.create(),
+      color: vec3.create(),
+      orbiting: vec3.create(),
+      orbitalAxis: V(1, 0, 0),
+    }),
+    updateProps: (
+      p,
       pos?: vec3,
       color?: vec3,
       orbiting?: vec3,
       orbitalAxis?: vec3
-    ) => ({
-      pos: pos ?? vec3.create(),
-      color: color ?? vec3.create(),
-      orbiting: orbiting ?? vec3.create(),
-      orbitalAxis: orbitalAxis ?? V(1, 0, 0),
-    }),
+    ) =>
+      Object.assign(p, {
+        pos: pos ?? vec3.create(),
+        color: color ?? vec3.create(),
+        orbiting: orbiting ?? vec3.create(),
+        orbitalAxis: orbitalAxis ?? V(1, 0, 0),
+      }),
     serializeProps: (o, buf) => {
       buf.writeVec3(o.pos);
       buf.writeVec3(o.color);

--- a/src/hyperspace/darkstar.ts
+++ b/src/hyperspace/darkstar.ts
@@ -20,24 +20,24 @@ export const { DarkStarPropsDef, DarkStarLocalDef, createDarkStarNow } =
   defineNetEntityHelper({
     name: "darkStar",
     defaultProps: () => ({
-      pos: vec3.create(),
-      color: vec3.create(),
-      orbiting: vec3.create(),
+      pos: V(0, 0, 0),
+      color: V(0, 0, 0),
+      orbiting: V(0, 0, 0),
       orbitalAxis: V(1, 0, 0),
     }),
     updateProps: (
       p,
-      pos?: vec3,
-      color?: vec3,
-      orbiting?: vec3,
-      orbitalAxis?: vec3
-    ) =>
-      Object.assign(p, {
-        pos: pos ?? vec3.create(),
-        color: color ?? vec3.create(),
-        orbiting: orbiting ?? vec3.create(),
-        orbitalAxis: orbitalAxis ?? V(1, 0, 0),
-      }),
+      pos?: vec3.InputT,
+      color?: vec3.InputT,
+      orbiting?: vec3.InputT,
+      orbitalAxis?: vec3.InputT
+    ) => {
+      if (pos) vec3.copy(p.pos, pos);
+      if (color) vec3.copy(p.color, color);
+      if (orbiting) vec3.copy(p.orbiting, orbiting);
+      if (orbitalAxis) vec3.copy(p.orbitalAxis, orbitalAxis);
+      return p;
+    },
     serializeProps: (o, buf) => {
       buf.writeVec3(o.pos);
       buf.writeVec3(o.color);

--- a/src/hyperspace/game-hyperspace.ts
+++ b/src/hyperspace/game-hyperspace.ts
@@ -142,7 +142,7 @@ export async function initHyperspaceGame() {
   res.camera.fov = Math.PI * 0.5;
 
   // const ghost = createGhost();
-  // EM.ensureComponentOn(ghost, RenderableConstructDef, res.allMeshes.cube.proto);
+  // EM.set(ghost, RenderableConstructDef, res.allMeshes.cube.proto);
   // ghost.controllable.speed *= 3;
   // ghost.controllable.sprintMul *= 3;
 

--- a/src/hyperspace/game-hyperspace.ts
+++ b/src/hyperspace/game-hyperspace.ts
@@ -174,13 +174,9 @@ export async function initHyperspaceGame() {
   if (me.host) {
     // experimental ship:
     const eShip = EM.new();
-    EM.ensureComponentOn(
-      eShip,
-      RenderableConstructDef,
-      res.allMeshes.ship_fangs.proto
-    );
-    EM.ensureComponentOn(eShip, PositionDef);
-    EM.ensureComponentOn(eShip, UVPosDef, vec2.clone([0.2, 0.1]));
+    EM.set(eShip, RenderableConstructDef, res.allMeshes.ship_fangs.proto);
+    EM.set(eShip, PositionDef);
+    EM.set(eShip, UVPosDef, vec2.clone([0.2, 0.1]));
 
     const ship = createHsShip(vec2.clone([0.1, 0.1]));
     const ship2 = await EM.whenEntityHas(ship, UVPosDef);

--- a/src/hyperspace/gem.ts
+++ b/src/hyperspace/gem.ts
@@ -12,9 +12,13 @@ import { InteractableDef } from "../input/interact.js";
 
 export const { GemPropsDef, GemLocalDef, createGem } = defineNetEntityHelper({
   name: "gem",
-  defaultProps: (shipId?: number) => ({
-    shipId: shipId ?? 0,
+  defaultProps: () => ({
+    shipId: 0,
   }),
+  updateProps: (p, shipId?: number) =>
+    Object.assign(p, {
+      shipId: shipId ?? 0,
+    }),
   serializeProps: (o, buf) => {
     buf.writeUint32(o.shipId);
   },

--- a/src/hyperspace/gem.ts
+++ b/src/hyperspace/gem.ts
@@ -29,26 +29,22 @@ export const { GemPropsDef, GemLocalDef, createGem } = defineNetEntityHelper({
   dynamicComponents: [],
   buildResources: [AllMeshesDef, MeDef],
   build: (gem, res) => {
-    EM.ensureComponentOn(gem, PositionDef, V(0, 0, 10));
+    EM.set(gem, PositionDef, V(0, 0, 10));
 
-    EM.ensureComponentOn(
-      gem,
-      RenderableConstructDef,
-      res.allMeshes.spacerock.proto
-    );
-    EM.ensureComponentOn(gem, PhysicsParentDef, gem.gemProps.shipId);
-    EM.ensureComponentOn(gem, ColorDef);
+    EM.set(gem, RenderableConstructDef, res.allMeshes.spacerock.proto);
+    EM.set(gem, PhysicsParentDef, gem.gemProps.shipId);
+    EM.set(gem, ColorDef);
 
     // create seperate hitbox for interacting with the gem
     const interactBox = EM.new();
     const interactAABB = copyAABB(createAABB(), res.allMeshes.spacerock.aabb);
-    EM.ensureComponentOn(interactBox, PhysicsParentDef, gem.id);
-    EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, 0));
-    EM.ensureComponentOn(interactBox, ColliderDef, {
+    EM.set(interactBox, PhysicsParentDef, gem.id);
+    EM.set(interactBox, PositionDef, V(0, 0, 0));
+    EM.set(interactBox, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: interactAABB,
     });
-    EM.ensureComponentOn(gem, InteractableDef, interactBox.id);
+    EM.set(gem, InteractableDef, interactBox.id);
   },
 });

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -59,7 +59,7 @@ export function createHsPlayer() {
   return e;
 }
 
-export const HsPlayerDef = EM.defineComponent2(
+export const HsPlayerDef = EM.defineComponent(
   "hsPlayer",
   () => {
     return {

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -92,10 +92,10 @@ export const LocalHsPlayerDef = EM.defineResource(
 
 export const PlayerHsPropsDef = defineSerializableComponent(
   "hsPlayerProps",
-  (loc?: vec3) => {
-    return {
-      location: loc ?? vec3.create(),
-    };
+  () => ({ location: vec3.create() }),
+  (p, loc?: vec3) => {
+    if (loc) vec3.copy(p.location, loc);
+    return p;
   },
   (c, writer) => {
     writer.writeVec3(c.location);

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -54,7 +54,7 @@ import { Phase } from "../ecs/sys-phase.js";
 export function createHsPlayer() {
   // console.log("create player!");
   const e = EM.new();
-  EM.ensureComponentOn(e, PlayerHsPropsDef, V(0, 100, 0));
+  EM.set(e, PlayerHsPropsDef, V(0, 100, 0));
   EM.addResource(LocalHsPlayerDef, e.id);
   return e;
 }
@@ -135,22 +135,18 @@ export function registerHsPlayerSystems() {
           scaleMesh3(m, V(0.75, 0.75, 0.4));
           EM.addComponent(e.id, RenderableConstructDef, m);
         }
-        EM.ensureComponentOn(e, AuthorityDef, res.me.pid);
+        EM.set(e, AuthorityDef, res.me.pid);
         if (!HsPlayerDef.isOn(e)) {
-          EM.ensureComponentOn(e, HsPlayerDef);
+          EM.set(e, HsPlayerDef);
 
           // create legs
           function makeLeg(x: number): Entity {
             const l = EM.new();
-            EM.ensureComponentOn(l, PositionDef, V(x, -1.5, 0));
-            EM.ensureComponentOn(
-              l,
-              RenderableConstructDef,
-              res.allMeshes.cube.proto
-            );
-            EM.ensureComponentOn(l, ScaleDef, V(0.15, 0.75, 0.15));
-            EM.ensureComponentOn(l, ColorDef, V(0.05, 0.05, 0.05));
-            EM.ensureComponentOn(l, PhysicsParentDef, e.id);
+            EM.set(l, PositionDef, V(x, -1.5, 0));
+            EM.set(l, RenderableConstructDef, res.allMeshes.cube.proto);
+            EM.set(l, ScaleDef, V(0.15, 0.75, 0.15));
+            EM.set(l, ColorDef, V(0.05, 0.05, 0.05));
+            EM.set(l, PhysicsParentDef, e.id);
             return l;
           }
           e.hsPlayer.leftLegId = makeLeg(-0.5).id;
@@ -166,7 +162,7 @@ export function registerHsPlayerSystems() {
           (collider as AABBCollider).aabb = playerAABB;
         }
         if (!SyncDef.isOn(e)) {
-          EM.ensureComponentOn(e, SyncDef, [
+          EM.set(e, SyncDef, [
             PositionDef.id,
             RotationDef.id,
             // TODO(@darzu): maybe sync this via events instead
@@ -174,10 +170,10 @@ export function registerHsPlayerSystems() {
           ]);
           e.sync.fullComponents = [PlayerHsPropsDef.id];
         }
-        EM.ensureComponent(e.id, PhysicsParentDef);
+        EM.set(e, PhysicsParentDef);
 
-        EM.ensureComponentOn(e, ControllableDef);
-        EM.ensureComponentOn(e, CameraFollowDef, 1);
+        EM.set(e, ControllableDef);
+        EM.set(e, CameraFollowDef, 1);
         setCameraFollowPosition(e, "thirdPersonOverShoulder");
 
         EM.addComponent(e.id, FinishedDef);

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -115,68 +115,56 @@ export function registerHsPlayerSystems() {
       for (let e of players) {
         if (FinishedDef.isOn(e)) continue;
         const props = e.hsPlayerProps;
-        if (!PositionDef.isOn(e))
-          EM.addComponent(e.id, PositionDef, props.location);
-        if (!RotationDef.isOn(e))
-          EM.addComponent(
-            e.id,
-            RotationDef,
-            quat.rotateY(quat.IDENTITY, Math.PI, quat.create())
-          );
-        if (!LinearVelocityDef.isOn(e))
-          EM.addComponent(e.id, LinearVelocityDef);
+        EM.set(e, PositionDef, props.location);
+        EM.set(
+          e,
+          RotationDef,
+          quat.rotateY(quat.IDENTITY, Math.PI, quat.create())
+        );
+        EM.set(e, LinearVelocityDef);
         // console.log("making player!");
-        if (!ColorDef.isOn(e)) EM.addComponent(e.id, ColorDef, V(0, 0.2, 0));
-        if (!MotionSmoothingDef.isOn(e))
-          EM.addComponent(e.id, MotionSmoothingDef);
-        if (!RenderableConstructDef.isOn(e)) {
-          // console.log("creating rend");
-          const m = cloneMesh(res.allMeshes.cube.mesh);
-          scaleMesh3(m, V(0.75, 0.75, 0.4));
-          EM.addComponent(e.id, RenderableConstructDef, m);
-        }
+        EM.set(e, ColorDef, V(0, 0.2, 0));
+        EM.set(e, MotionSmoothingDef);
+        // console.log("creating rend");
+        const m = cloneMesh(res.allMeshes.cube.mesh);
+        scaleMesh3(m, V(0.75, 0.75, 0.4));
+        EM.set(e, RenderableConstructDef, m);
         EM.set(e, AuthorityDef, res.me.pid);
-        if (!HsPlayerDef.isOn(e)) {
-          EM.set(e, HsPlayerDef);
+        EM.set(e, HsPlayerDef);
 
-          // create legs
-          function makeLeg(x: number): Entity {
-            const l = EM.new();
-            EM.set(l, PositionDef, V(x, -1.5, 0));
-            EM.set(l, RenderableConstructDef, res.allMeshes.cube.proto);
-            EM.set(l, ScaleDef, V(0.15, 0.75, 0.15));
-            EM.set(l, ColorDef, V(0.05, 0.05, 0.05));
-            EM.set(l, PhysicsParentDef, e.id);
-            return l;
-          }
-          e.hsPlayer.leftLegId = makeLeg(-0.5).id;
-          e.hsPlayer.rightLegId = makeLeg(0.5).id;
+        // create legs
+        function makeLeg(x: number): Entity {
+          const l = EM.new();
+          EM.set(l, PositionDef, V(x, -1.5, 0));
+          EM.set(l, RenderableConstructDef, res.allMeshes.cube.proto);
+          EM.set(l, ScaleDef, V(0.15, 0.75, 0.15));
+          EM.set(l, ColorDef, V(0.05, 0.05, 0.05));
+          EM.set(l, PhysicsParentDef, e.id);
+          return l;
         }
-        if (!ColliderDef.isOn(e)) {
-          const collider = EM.addComponent(e.id, ColliderDef);
-          collider.shape = "AABB";
-          // collider.solid = false;
-          collider.solid = true;
-          const playerAABB = copyAABB(createAABB(), res.allMeshes.cube.aabb);
-          vec3.add(playerAABB.min, [0, -1, 0], playerAABB.min);
-          (collider as AABBCollider).aabb = playerAABB;
-        }
-        if (!SyncDef.isOn(e)) {
-          EM.set(e, SyncDef, [
-            PositionDef.id,
-            RotationDef.id,
-            // TODO(@darzu): maybe sync this via events instead
-            PhysicsParentDef.id,
-          ]);
-          e.sync.fullComponents = [PlayerHsPropsDef.id];
-        }
+        e.hsPlayer.leftLegId = makeLeg(-0.5).id;
+        e.hsPlayer.rightLegId = makeLeg(0.5).id;
+        const aabb = copyAABB(createAABB(), res.allMeshes.cube.aabb);
+        vec3.add(aabb.min, [0, -1, 0], aabb.min);
+        EM.set(e, ColliderDef, {
+          shape: "AABB",
+          solid: true,
+          aabb,
+        });
+        EM.set(e, SyncDef, [
+          PositionDef.id,
+          RotationDef.id,
+          // TODO(@darzu): maybe sync this via events instead
+          PhysicsParentDef.id,
+        ]);
+        e.sync.fullComponents = [PlayerHsPropsDef.id];
         EM.set(e, PhysicsParentDef);
 
         EM.set(e, ControllableDef);
         EM.set(e, CameraFollowDef, 1);
         setCameraFollowPosition(e, "thirdPersonOverShoulder");
 
-        EM.addComponent(e.id, FinishedDef);
+        EM.set(e, FinishedDef);
       }
     }
   );

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -59,28 +59,32 @@ export function createHsPlayer() {
   return e;
 }
 
-export const HsPlayerDef = EM.defineComponent("hsPlayer", () => {
-  return {
-    // hat stuff
-    // TODO(@darzu): better abstraction
-    hat: 0,
-    tool: 0,
-    interacting: false,
-    clicking: false,
-    manning: false,
-    dropping: false,
-    leftLegId: 0,
-    rightLegId: 0,
-    facingDir: vec3.create(),
-    // TODO(@darzu): HACK. hyperspace game specific
-    lookingForShip: true,
-    // TODO(@darzu): HACK. LD51 game specific
-    holdingBall: 0,
-    // disabled noodle limbs
-    // leftFootWorldPos: [0, 0, 0] as vec3,
-    // rightFootWorldPos: [0, 0, 0] as vec3,
-  };
-});
+export const HsPlayerDef = EM.defineComponent2(
+  "hsPlayer",
+  () => {
+    return {
+      // hat stuff
+      // TODO(@darzu): better abstraction
+      hat: 0,
+      tool: 0,
+      interacting: false,
+      clicking: false,
+      manning: false,
+      dropping: false,
+      leftLegId: 0,
+      rightLegId: 0,
+      facingDir: vec3.create(),
+      // TODO(@darzu): HACK. hyperspace game specific
+      lookingForShip: true,
+      // TODO(@darzu): HACK. LD51 game specific
+      holdingBall: 0,
+      // disabled noodle limbs
+      // leftFootWorldPos: [0, 0, 0] as vec3,
+      // rightFootWorldPos: [0, 0, 0] as vec3,
+    };
+  },
+  (p) => p
+);
 
 // Resource pointing at the local player
 export const LocalHsPlayerDef = EM.defineResource(

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -464,7 +464,7 @@ export function registerHsPlayerSystems() {
             vec3.zero(p.linearVelocity);
 
             // TODO(@darzu): uncomment to animate player entry
-            // EM.ensureComponentOn(p, AnimateToDef, {
+            // EM.set(p, AnimateToDef, {
             //   startPos,
             //   endPos,
             //   durationMs: 2000,

--- a/src/hyperspace/hs-player.ts
+++ b/src/hyperspace/hs-player.ts
@@ -59,32 +59,28 @@ export function createHsPlayer() {
   return e;
 }
 
-export const HsPlayerDef = EM.defineComponent(
-  "hsPlayer",
-  () => {
-    return {
-      // hat stuff
-      // TODO(@darzu): better abstraction
-      hat: 0,
-      tool: 0,
-      interacting: false,
-      clicking: false,
-      manning: false,
-      dropping: false,
-      leftLegId: 0,
-      rightLegId: 0,
-      facingDir: vec3.create(),
-      // TODO(@darzu): HACK. hyperspace game specific
-      lookingForShip: true,
-      // TODO(@darzu): HACK. LD51 game specific
-      holdingBall: 0,
-      // disabled noodle limbs
-      // leftFootWorldPos: [0, 0, 0] as vec3,
-      // rightFootWorldPos: [0, 0, 0] as vec3,
-    };
-  },
-  (p) => p
-);
+export const HsPlayerDef = EM.defineComponent("hsPlayer", () => {
+  return {
+    // hat stuff
+    // TODO(@darzu): better abstraction
+    hat: 0,
+    tool: 0,
+    interacting: false,
+    clicking: false,
+    manning: false,
+    dropping: false,
+    leftLegId: 0,
+    rightLegId: 0,
+    facingDir: vec3.create(),
+    // TODO(@darzu): HACK. hyperspace game specific
+    lookingForShip: true,
+    // TODO(@darzu): HACK. LD51 game specific
+    holdingBall: 0,
+    // disabled noodle limbs
+    // leftFootWorldPos: [0, 0, 0] as vec3,
+    // rightFootWorldPos: [0, 0, 0] as vec3,
+  };
+});
 
 // Resource pointing at the local player
 export const LocalHsPlayerDef = EM.defineResource(

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -92,15 +92,11 @@ export const { HypMastPropsDef, HypMastLocalDef, createHypMastNow } =
     dynamicComponents: [RotationDef, BoomPitchesDef],
     buildResources: [AllMeshesDef, MeDef],
     build: (mast, res) => {
-      EM.ensureComponentOn(mast, PositionDef, V(0, 0, 0));
+      EM.set(mast, PositionDef, V(0, 0, 0));
 
-      EM.ensureComponentOn(
-        mast,
-        RenderableConstructDef,
-        res.allMeshes.mast.mesh
-      );
-      EM.ensureComponentOn(mast, PhysicsParentDef, mast.hypMastProps.shipId);
-      EM.ensureComponentOn(mast, ColorDef, ENDESGA16.lightBrown);
+      EM.set(mast, RenderableConstructDef, res.allMeshes.mast.mesh);
+      EM.set(mast, PhysicsParentDef, mast.hypMastProps.shipId);
+      EM.set(mast, ColorDef, ENDESGA16.lightBrown);
       vec3.scale(mast.color, 0.5, mast.color);
 
       // createRib(mast.id, BOOM_HEIGHT)
@@ -135,13 +131,9 @@ export const { HypMastPropsDef, HypMastLocalDef, createHypMastNow } =
 
       // create seperate hitbox for interacting with the mast
       const interactBox = EM.new();
-      EM.ensureComponentOn(
-        interactBox,
-        PhysicsParentDef,
-        mast.hypMastProps.shipId
-      );
-      EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, 0));
-      EM.ensureComponentOn(interactBox, ColliderDef, {
+      EM.set(interactBox, PhysicsParentDef, mast.hypMastProps.shipId);
+      EM.set(interactBox, PositionDef, V(0, 0, 0));
+      EM.set(interactBox, ColliderDef, {
         shape: "AABB",
         solid: false,
         aabb: {

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -59,9 +59,13 @@ const SailColorDef = EM.defineComponent(
 export const { HypMastPropsDef, HypMastLocalDef, createHypMastNow } =
   defineNetEntityHelper({
     name: "hypMast",
-    defaultProps: (shipId?: number) => ({
-      shipId: shipId ?? 0,
+    defaultProps: () => ({
+      shipId: 0,
     }),
+    updateProps: (p, shipId?: number) =>
+      Object.assign(p, {
+        shipId: shipId ?? 0,
+      }),
     serializeProps: (o, buf) => {
       buf.writeUint32(o.shipId);
     },

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -34,14 +34,10 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // TODO(@darzu): refactor this so that our towers can use this
 
-const BoomPitchesDef = EM.defineComponent(
-  "boomPitches",
-  () => ({
-    boom1: Math.PI / 4,
-    boom2: Math.PI / 4,
-  }),
-  (p) => p
-);
+const BoomPitchesDef = EM.defineComponent("boomPitches", () => ({
+  boom1: Math.PI / 4,
+  boom2: Math.PI / 4,
+}));
 EM.registerSerializerPair(
   BoomPitchesDef,
   (c, writer) => {

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -106,17 +106,17 @@ export const { HypMastPropsDef, HypMastLocalDef, createHypMastNow } =
       // const sail1 = TODO; // TODO(@darzu):
 
       // const sail2 = EM.new();
-      // EM.ensureComponentOn(sail2, PositionDef, V(0, BOOM_HEIGHT, 0));
-      // EM.ensureComponentOn(
+      // EM.set(sail2, PositionDef, V(0, BOOM_HEIGHT, 0));
+      // EM.set(
       //   sail2,
       //   RenderableConstructDef,
       //   cloneMesh(res.allMeshes.sail.mesh)
       // );
-      // //EM.ensureComponentOn(sail2, ScaleDef, [12, 12, 12]);
-      // EM.ensureComponentOn(sail2, RotationDef);
-      // EM.ensureComponentOn(sail2, SailColorDef, STAR2_COLOR);
-      // EM.ensureComponentOn(sail2, ColorDef, DEFAULT_SAIL_COLOR);
-      // EM.ensureComponentOn(sail2, PhysicsParentDef, mast.id);
+      // //EM.set(sail2, ScaleDef, [12, 12, 12]);
+      // EM.set(sail2, RotationDef);
+      // EM.set(sail2, SailColorDef, STAR2_COLOR);
+      // EM.set(sail2, ColorDef, DEFAULT_SAIL_COLOR);
+      // EM.set(sail2, PhysicsParentDef, mast.id);
       // EM.whenEntityHas(
       //   sail2,
       //   RenderDataStdDef,

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -34,7 +34,7 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // TODO(@darzu): refactor this so that our towers can use this
 
-const BoomPitchesDef = EM.defineComponent2(
+const BoomPitchesDef = EM.defineComponent(
   "boomPitches",
   () => ({
     boom1: Math.PI / 4,
@@ -54,7 +54,7 @@ EM.registerSerializerPair(
   }
 );
 
-const SailColorDef = EM.defineComponent2(
+const SailColorDef = EM.defineComponent(
   "sailColor",
   () => vec3.create(),
   (p, color?: vec3) => (color ? vec3.copy(p, color) : p)

--- a/src/hyperspace/hypersail.ts
+++ b/src/hyperspace/hypersail.ts
@@ -34,10 +34,14 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // TODO(@darzu): refactor this so that our towers can use this
 
-const BoomPitchesDef = EM.defineComponent("boomPitches", () => ({
-  boom1: Math.PI / 4,
-  boom2: Math.PI / 4,
-}));
+const BoomPitchesDef = EM.defineComponent2(
+  "boomPitches",
+  () => ({
+    boom1: Math.PI / 4,
+    boom2: Math.PI / 4,
+  }),
+  (p) => p
+);
 EM.registerSerializerPair(
   BoomPitchesDef,
   (c, writer) => {
@@ -50,9 +54,10 @@ EM.registerSerializerPair(
   }
 );
 
-const SailColorDef = EM.defineComponent(
+const SailColorDef = EM.defineComponent2(
   "sailColor",
-  (color?: vec3) => color ?? vec3.create()
+  () => vec3.create(),
+  (p, color?: vec3) => (color ? vec3.copy(p, color) : p)
 );
 
 // TODO: we need warnings if you forget to call the buildProps system!

--- a/src/hyperspace/hyperspace-gamestate.ts
+++ b/src/hyperspace/hyperspace-gamestate.ts
@@ -61,9 +61,9 @@ export const endGame = eventWizard(
     res.hsGameState.time = 0;
     for (const partRef of ship.hsShipLocal.parts) {
       const part = partRef();
-      if (part) EM.ensureComponentOn(part, DeletedDef);
+      if (part) EM.set(part, DeletedDef);
     }
-    EM.ensureComponentOn(ship, DeletedDef);
+    EM.set(ship, DeletedDef);
     if (ship.hsShipProps.cannonLId)
       EM.ensureComponent(ship.hsShipProps.cannonLId, DeletedDef);
     if (ship.hsShipProps.cannonRId)
@@ -91,11 +91,11 @@ export const endGame = eventWizard(
       PhysicsParentDef,
     ])!;
     vec3.copy(gem.position, gem.world.position);
-    EM.ensureComponentOn(gem, RotationDef);
+    EM.set(gem, RotationDef);
     quat.copy(gem.rotation, gem.world.rotation);
-    EM.ensureComponentOn(gem, LinearVelocityDef, V(0, 0.01, 0));
+    EM.set(gem, LinearVelocityDef, V(0, 0.01, 0));
     EM.removeComponent(gem.id, PhysicsParentDef);
-    EM.ensureComponentOn(gem, LifetimeDef, 4000);
+    EM.set(gem, LifetimeDef, 4000);
   },
   {
     legalEvent: () =>

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -58,7 +58,7 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // export const BOAT_COLOR: vec3 = V(0.2, 0.1, 0.05);
 
-export const ShipPartDef = EM.defineComponent2(
+export const ShipPartDef = EM.defineComponent(
   "shipPart",
   () => ({
     critical: false,

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -138,14 +138,23 @@ export const { RudderPropsDef, RudderLocalDef, createRudderNow } =
 export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
   defineNetEntityHelper({
     name: "hsShip",
-    defaultProps: (uvPos?: vec2) => ({
-      uvPos: uvPos ?? vec2.fromValues(0.5, 0.5),
+    defaultProps: () => ({
+      uvPos: vec2.fromValues(0.5, 0.5),
       gemId: 0,
       cannonLId: 0,
       cannonRId: 0,
       rudder: createRef(0, [RudderPropsDef, YawPitchDef]),
       mast: createRef(0, [HypMastPropsDef, HypMastLocalDef]),
     }),
+    updateProps: (p, uvPos?: vec2) =>
+      Object.assign(p, {
+        uvPos: uvPos ?? vec2.fromValues(0.5, 0.5),
+        gemId: 0,
+        cannonLId: 0,
+        cannonRId: 0,
+        rudder: createRef(0, [RudderPropsDef, YawPitchDef]),
+        mast: createRef(0, [HypMastPropsDef, HypMastLocalDef]),
+      }),
     serializeProps: (c, buf) => {
       buf.writeVec2(c.uvPos);
       buf.writeUint32(c.gemId);

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -212,8 +212,8 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
 
       s.uvship.speed = 0;
       // s.hsShipLocal.speed = 0.005 * 3; // TODO(@darzu): DEBUG SPEED
-      // EM.ensureComponentOn(s, LinearVelocityDef, [0, 0, 0]);
-      // EM.ensureComponentOn(s, AngularVelocityDef);
+      // EM.set(s, LinearVelocityDef, [0, 0, 0]);
+      // EM.set(s, AngularVelocityDef);
 
       const mc: MultiCollider = {
         shape: "Multi",
@@ -262,7 +262,7 @@ const criticalPartIdxes = [0, 3, 5, 6];
 //   EM.registerOneShotSystem(null, [AssetsDef], (_, res) => {
 //     // create ship
 //     const s = EM.newEntity();
-//     EM.ensureComponentOn(s, ShipConstructDef);
+//     EM.set(s, ShipConstructDef);
 //   });
 // }
 

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -58,16 +58,12 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // export const BOAT_COLOR: vec3 = V(0.2, 0.1, 0.05);
 
-export const ShipPartDef = EM.defineComponent(
+export const ShipPartDef = EM.defineNonupdatableComponent(
   "shipPart",
-  () => ({
-    critical: false,
+  (critical: boolean) => ({
+    critical,
     damaged: false,
-  }),
-  (p, critical: boolean) => {
-    p.critical = critical;
-    return p;
-  }
+  })
 );
 
 export const { RudderPropsDef, RudderLocalDef, createRudderNow } =
@@ -150,15 +146,10 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
       rudder: createRef(0, [RudderPropsDef, YawPitchDef]),
       mast: createRef(0, [HypMastPropsDef, HypMastLocalDef]),
     }),
-    updateProps: (p, uvPos?: vec2) =>
-      Object.assign(p, {
-        uvPos: uvPos ?? vec2.fromValues(0.5, 0.5),
-        gemId: 0,
-        cannonLId: 0,
-        cannonRId: 0,
-        rudder: createRef(0, [RudderPropsDef, YawPitchDef]),
-        mast: createRef(0, [HypMastPropsDef, HypMastLocalDef]),
-      }),
+    updateProps: (p, uvPos?: vec2.InputT) => {
+      if (uvPos) vec2.copy(p.uvPos, uvPos);
+      return p;
+    },
     serializeProps: (c, buf) => {
       buf.writeVec2(c.uvPos);
       buf.writeUint32(c.gemId);

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -69,9 +69,13 @@ export const ShipPartDef = EM.defineComponent(
 export const { RudderPropsDef, RudderLocalDef, createRudderNow } =
   defineNetEntityHelper({
     name: "rudder",
-    defaultProps: (shipId?: number) => ({
-      shipId: shipId ?? 0,
+    defaultProps: () => ({
+      shipId: 0,
     }),
+    updateProps: (p, shipId?: number) =>
+      Object.assign(p, {
+        shipId: shipId ?? 0,
+      }),
     serializeProps: (o, buf) => {
       buf.writeUint32(o.shipId);
     },

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -58,12 +58,16 @@ import { Phase } from "../ecs/sys-phase.js";
 
 // export const BOAT_COLOR: vec3 = V(0.2, 0.1, 0.05);
 
-export const ShipPartDef = EM.defineComponent(
+export const ShipPartDef = EM.defineComponent2(
   "shipPart",
-  (critical: boolean) => ({
-    critical,
+  () => ({
+    critical: false,
     damaged: false,
-  })
+  }),
+  (p, critical: boolean) => {
+    p.critical = critical;
+    return p;
+  }
 );
 
 export const { RudderPropsDef, RudderLocalDef, createRudderNow } =

--- a/src/hyperspace/hyperspace-ship.ts
+++ b/src/hyperspace/hyperspace-ship.ts
@@ -86,26 +86,18 @@ export const { RudderPropsDef, RudderLocalDef, createRudderNow } =
     dynamicComponents: [RotationDef],
     buildResources: [AllMeshesDef, MeDef],
     build: (rudder, res) => {
-      EM.ensureComponentOn(rudder, PositionDef, V(0, 0.5, -15));
+      EM.set(rudder, PositionDef, V(0, 0.5, -15));
 
-      EM.ensureComponentOn(
-        rudder,
-        RenderableConstructDef,
-        res.allMeshes.rudder.mesh
-      );
-      EM.ensureComponentOn(rudder, PhysicsParentDef, rudder.rudderProps.shipId);
-      EM.ensureComponentOn(rudder, ColorDef, ENDESGA16.lightBrown);
+      EM.set(rudder, RenderableConstructDef, res.allMeshes.rudder.mesh);
+      EM.set(rudder, PhysicsParentDef, rudder.rudderProps.shipId);
+      EM.set(rudder, ColorDef, ENDESGA16.lightBrown);
       vec3.scale(rudder.color, 0.5, rudder.color);
 
       // create seperate hitbox for interacting with the rudder
       const interactBox = EM.new();
-      EM.ensureComponentOn(
-        interactBox,
-        PhysicsParentDef,
-        rudder.rudderProps.shipId
-      );
-      EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, -12));
-      EM.ensureComponentOn(interactBox, ColliderDef, {
+      EM.set(interactBox, PhysicsParentDef, rudder.rudderProps.shipId);
+      EM.set(interactBox, PositionDef, V(0, 0, -12));
+      EM.set(interactBox, ColliderDef, {
         shape: "AABB",
         solid: false,
         aabb: {
@@ -141,7 +133,7 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
     defaultProps: () => ({
       uvPos: vec2.fromValues(0.5, 0.5),
       gemId: 0,
-      cannonLId: 0,
+      cannonLId: 0, // TODO(@darzu): use refs?
       cannonRId: 0,
       rudder: createRef(0, [RudderPropsDef, YawPitchDef]),
       mast: createRef(0, [HypMastPropsDef, HypMastLocalDef]),
@@ -211,12 +203,12 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
       vec2.copy(s.uvPos, s.hsShipProps.uvPos);
       vec2.set(1, 0, s.uvDir);
 
-      EM.ensureComponentOn(s, PositionDef);
-      EM.ensureComponentOn(s, RotationDef);
+      EM.set(s, PositionDef);
+      EM.set(s, RotationDef);
 
-      EM.ensureComponentOn(s, MotionSmoothingDef);
+      EM.set(s, MotionSmoothingDef);
 
-      EM.ensureComponentOn(s, UVShipDef);
+      EM.set(s, UVShipDef);
 
       s.uvship.speed = 0;
       // s.hsShipLocal.speed = 0.005 * 3; // TODO(@darzu): DEBUG SPEED
@@ -233,7 +225,7 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
           aabb,
         })),
       };
-      EM.ensureComponentOn(s, ColliderDef, mc);
+      EM.set(s, ColliderDef, mc);
 
       // NOTE: since their is no network important state on the parts themselves
       //    they can be created locally
@@ -241,13 +233,13 @@ export const { HsShipPropsDef, HsShipLocalDef, createHsShip } =
       for (let i = 0; i < res.allMeshes.ship_broken.length; i++) {
         const m = res.allMeshes.ship_broken[i];
         const part = EM.new();
-        EM.ensureComponentOn(part, PhysicsParentDef, s.id);
-        EM.ensureComponentOn(part, RenderableConstructDef, m.proto);
-        EM.ensureComponentOn(part, ColorDef, ENDESGA16.lightBrown);
-        EM.ensureComponentOn(part, PositionDef, V(0, 0, 0));
+        EM.set(part, PhysicsParentDef, s.id);
+        EM.set(part, RenderableConstructDef, m.proto);
+        EM.set(part, ColorDef, ENDESGA16.lightBrown);
+        EM.set(part, PositionDef, V(0, 0, 0));
         const isCritical = criticalPartIdxes.includes(i);
-        EM.ensureComponentOn(part, ShipPartDef, isCritical);
-        EM.ensureComponentOn(part, ColliderDef, {
+        EM.set(part, ShipPartDef, isCritical);
+        EM.set(part, ColliderDef, {
           shape: "AABB",
           solid: false,
           aabb: m.aabb,
@@ -348,8 +340,7 @@ export function registerShipSystems() {
               ?.map((h) => EM.findEntity(h, [BulletDef]))
               .filter((h) => h && h.bullet.team === 2);
             if (bullets && bullets.length) {
-              for (let b of bullets)
-                if (b) EM.ensureComponent(b.id, DeletedDef);
+              for (let b of bullets) if (b) EM.set(b, DeletedDef);
 
               raiseShipHit(ship, i);
             }

--- a/src/hyperspace/orrery.ts
+++ b/src/hyperspace/orrery.ts
@@ -19,25 +19,21 @@ const ORRERY_SCALE = 0.001;
 export async function makeOrrery(parentId: number) {
   const res = await EM.whenResources(AllMeshesDef);
   const orrery = EM.new();
-  EM.ensureComponentOn(orrery, OrreryDef);
-  EM.ensureComponentOn(orrery, PhysicsParentDef, parentId);
-  EM.ensureComponentOn(orrery, PositionDef, V(0, 4, 4));
+  EM.set(orrery, OrreryDef);
+  EM.set(orrery, PhysicsParentDef, parentId);
+  EM.set(orrery, PositionDef, V(0, 4, 4));
 
   // put a ship model at the center of it
   const shipModel = EM.new();
-  EM.ensureComponentOn(shipModel, PhysicsParentDef, orrery.id);
-  EM.ensureComponentOn(shipModel, PositionDef, V(0, 0, 0));
-  EM.ensureComponentOn(
-    shipModel,
-    RenderableConstructDef,
-    res.allMeshes.ship.proto
-  );
-  EM.ensureComponentOn(
+  EM.set(shipModel, PhysicsParentDef, orrery.id);
+  EM.set(shipModel, PositionDef, V(0, 0, 0));
+  EM.set(shipModel, RenderableConstructDef, res.allMeshes.ship.proto);
+  EM.set(
     shipModel,
     ScaleDef,
     V(ORRERY_SCALE * 40, ORRERY_SCALE * 40, ORRERY_SCALE * 40)
   );
-  EM.ensureComponentOn(shipModel, ColorDef, ENDESGA16.lightBrown);
+  EM.set(shipModel, ColorDef, ENDESGA16.lightBrown);
 }
 
 export const OrreryDef = EM.defineComponent("orrery", () => ({
@@ -61,15 +57,11 @@ export function registerOrrerySystems() {
         // TODO(@darzu): use resizeArray?
         while (orrery.orrery.orreryStars.length < stars.length) {
           const orreryStar = EM.new();
-          EM.ensureComponentOn(orreryStar, PositionDef);
-          EM.ensureComponentOn(orreryStar, PhysicsParentDef, orrery.id);
-          EM.ensureComponentOn(orreryStar, ColorDef);
-          EM.ensureComponentOn(
-            orreryStar,
-            RenderableConstructDef,
-            res.allMeshes.ball.proto
-          );
-          EM.ensureComponentOn(orreryStar, ScaleDef, V(0.25, 0.25, 0.25));
+          EM.set(orreryStar, PositionDef);
+          EM.set(orreryStar, PhysicsParentDef, orrery.id);
+          EM.set(orreryStar, ColorDef);
+          EM.set(orreryStar, RenderableConstructDef, res.allMeshes.ball.proto);
+          EM.set(orreryStar, ScaleDef, V(0.25, 0.25, 0.25));
           orrery.orrery.orreryStars.push(createRef(orreryStar));
         }
         const intoOrrerySpace = mat4.invert(orrery.world.transform);

--- a/src/hyperspace/orrery.ts
+++ b/src/hyperspace/orrery.ts
@@ -40,9 +40,13 @@ export async function makeOrrery(parentId: number) {
   EM.ensureComponentOn(shipModel, ColorDef, ENDESGA16.lightBrown);
 }
 
-export const OrreryDef = EM.defineComponent("orrery", () => ({
-  orreryStars: [] as Ref<[typeof PositionDef, typeof ColorDef]>[],
-}));
+export const OrreryDef = EM.defineComponent2(
+  "orrery",
+  () => ({
+    orreryStars: [] as Ref<[typeof PositionDef, typeof ColorDef]>[],
+  }),
+  (p) => p
+);
 
 export function registerOrrerySystems() {
   EM.addSystem(

--- a/src/hyperspace/orrery.ts
+++ b/src/hyperspace/orrery.ts
@@ -40,13 +40,9 @@ export async function makeOrrery(parentId: number) {
   EM.ensureComponentOn(shipModel, ColorDef, ENDESGA16.lightBrown);
 }
 
-export const OrreryDef = EM.defineComponent(
-  "orrery",
-  () => ({
-    orreryStars: [] as Ref<[typeof PositionDef, typeof ColorDef]>[],
-  }),
-  (p) => p
-);
+export const OrreryDef = EM.defineComponent("orrery", () => ({
+  orreryStars: [] as Ref<[typeof PositionDef, typeof ColorDef]>[],
+}));
 
 export function registerOrrerySystems() {
   EM.addSystem(

--- a/src/hyperspace/orrery.ts
+++ b/src/hyperspace/orrery.ts
@@ -40,7 +40,7 @@ export async function makeOrrery(parentId: number) {
   EM.ensureComponentOn(shipModel, ColorDef, ENDESGA16.lightBrown);
 }
 
-export const OrreryDef = EM.defineComponent2(
+export const OrreryDef = EM.defineComponent(
   "orrery",
   () => ({
     orreryStars: [] as Ref<[typeof PositionDef, typeof ColorDef]>[],

--- a/src/hyperspace/ribsail.ts
+++ b/src/hyperspace/ribsail.ts
@@ -41,6 +41,7 @@ export const { RibSailPropsDef, RibSailLocalDef, createRibSailNow } =
     defaultProps: () => ({
       // pitch: Math.PI / 2,
     }),
+    updateProps: (p) => p,
     serializeProps: (o, buf) => {
       // buf.writeFloat32(o.pitch);
     },

--- a/src/hyperspace/ribsail.ts
+++ b/src/hyperspace/ribsail.ts
@@ -67,13 +67,13 @@ export const { RibSailPropsDef, RibSailLocalDef, createRibSailNow } =
       // const sail = EM.new();
 
       EM.set(sail, PositionDef, V(0, 0, 0));
-      // EM.ensureComponentOn(sail, PositionDef, V(0, 0, 0));
+      // EM.set(sail, PositionDef, V(0, 0, 0));
       EM.set(sail, RenderableConstructDef, cloneMesh(res.allMeshes.sail.mesh));
-      //EM.ensureComponentOn(sail1, ScaleDef, [12, 12, 12]);
+      //EM.set(sail1, ScaleDef, [12, 12, 12]);
       EM.set(sail, RotationDef);
-      // EM.ensureComponentOn(sail, SailColorDef, STAR1_COLOR);
+      // EM.set(sail, SailColorDef, STAR1_COLOR);
       EM.set(sail, ColorDef, DEFAULT_SAIL_COLOR);
-      // EM.ensureComponentOn(sail, PhysicsParentDef, mast.id);
+      // EM.set(sail, PhysicsParentDef, mast.id);
       EM.whenEntityHas(
         sail,
         RenderDataStdDef

--- a/src/hyperspace/ribsail.ts
+++ b/src/hyperspace/ribsail.ts
@@ -66,17 +66,13 @@ export const { RibSailPropsDef, RibSailLocalDef, createRibSailNow } =
     build: (sail, res) => {
       // const sail = EM.new();
 
-      EM.ensureComponentOn(sail, PositionDef, V(0, 0, 0));
+      EM.set(sail, PositionDef, V(0, 0, 0));
       // EM.ensureComponentOn(sail, PositionDef, V(0, 0, 0));
-      EM.ensureComponentOn(
-        sail,
-        RenderableConstructDef,
-        cloneMesh(res.allMeshes.sail.mesh)
-      );
+      EM.set(sail, RenderableConstructDef, cloneMesh(res.allMeshes.sail.mesh));
       //EM.ensureComponentOn(sail1, ScaleDef, [12, 12, 12]);
-      EM.ensureComponentOn(sail, RotationDef);
+      EM.set(sail, RotationDef);
       // EM.ensureComponentOn(sail, SailColorDef, STAR1_COLOR);
-      EM.ensureComponentOn(sail, ColorDef, DEFAULT_SAIL_COLOR);
+      EM.set(sail, ColorDef, DEFAULT_SAIL_COLOR);
       // EM.ensureComponentOn(sail, PhysicsParentDef, mast.id);
       EM.whenEntityHas(
         sail,
@@ -92,15 +88,11 @@ export const { RibSailPropsDef, RibSailLocalDef, createRibSailNow } =
 
       const mast = EM.new();
 
-      EM.ensureComponentOn(mast, PositionDef, V(0, -20, 0));
-      EM.ensureComponentOn(mast, ScaleDef, V(0.5, 1.0, 0.5));
-      EM.ensureComponentOn(
-        mast,
-        RenderableConstructDef,
-        res.allMeshes.mast.mesh
-      );
-      EM.ensureComponentOn(mast, PhysicsParentDef, sail.id);
-      EM.ensureComponentOn(mast, ColorDef, ENDESGA16.lightBrown);
+      EM.set(mast, PositionDef, V(0, -20, 0));
+      EM.set(mast, ScaleDef, V(0.5, 1.0, 0.5));
+      EM.set(mast, RenderableConstructDef, res.allMeshes.mast.mesh);
+      EM.set(mast, PhysicsParentDef, sail.id);
+      EM.set(mast, ColorDef, ENDESGA16.lightBrown);
       vec3.scale(mast.color, 0.5, mast.color);
 
       sail.ribSailLocal.ribs = range(RIB_COUNT).map((i) => {
@@ -111,17 +103,13 @@ export const { RibSailPropsDef, RibSailLocalDef, createRibSailNow } =
 
       function createRib(width: number) {
         const rib = EM.new();
-        EM.ensureComponentOn(rib, PositionDef);
-        EM.ensureComponentOn(
-          rib,
-          RenderableConstructDef,
-          res.allMeshes.mast.mesh
-        );
-        EM.ensureComponentOn(rib, ScaleDef, V(0.5 * width, 0.5, 0.5 * width));
-        EM.ensureComponentOn(rib, RotationDef);
-        EM.ensureComponentOn(rib, ColorDef, ENDESGA16.lightBrown);
+        EM.set(rib, PositionDef);
+        EM.set(rib, RenderableConstructDef, res.allMeshes.mast.mesh);
+        EM.set(rib, ScaleDef, V(0.5 * width, 0.5, 0.5 * width));
+        EM.set(rib, RotationDef);
+        EM.set(rib, ColorDef, ENDESGA16.lightBrown);
         vec3.scale(rib.color, 0.7, rib.color);
-        EM.ensureComponentOn(rib, PhysicsParentDef, sail.id);
+        EM.set(rib, PhysicsParentDef, sail.id);
         return rib;
       }
 

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -37,16 +37,12 @@ import { ColorDef } from "../color/color-ecs.js";
 import { AudioDef, Music } from "../audio/audio.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const EnemyCrewDef = EM.defineComponent(
-  "enemyCrew",
-  () => {
-    return {
-      leftLegId: 0,
-      rightLegId: 0,
-    };
-  },
-  (p) => p
-);
+export const EnemyCrewDef = EM.defineComponent("enemyCrew", () => {
+  return {
+    leftLegId: 0,
+    rightLegId: 0,
+  };
+});
 
 export type EnemyCrew = Component<typeof EnemyCrewDef>;
 
@@ -93,19 +89,18 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
     },
     updateProps: (
       p,
-      uvLoc?: vec2,
+      uvLoc?: vec2.InputT,
       speed?: number,
       wheelSpeed?: number,
-      uvDir?: vec2,
+      uvDir?: vec2.InputT,
       parent?: number
     ) => {
-      return Object.assign(p, {
-        uvLoc: uvLoc ?? vec2.fromValues(0, 0),
-        speed: speed ?? 0.0,
-        wheelSpeed: wheelSpeed ?? 0.0,
-        uvDir: uvDir ?? vec2.fromValues(1, 0),
-        parent: parent ?? 0,
-      });
+      if (uvLoc) vec2.copy(p.uvLoc, uvLoc);
+      if (speed !== undefined) p.speed = speed;
+      if (wheelSpeed !== undefined) p.wheelSpeed = wheelSpeed;
+      if (uvDir) vec2.copy(p.uvDir, uvDir);
+      if (parent !== undefined) p.parent = parent;
+      return p;
     },
     serializeProps: (c, buf) => {
       buf.writeVec2(c.uvLoc);
@@ -383,11 +378,7 @@ export function breakEnemyShip(
   }
 }
 
-export const FireZoneDef = EM.defineComponent(
-  "firezone",
-  () => {},
-  (p) => p
-);
+export const FireZoneDef = EM.defineComponent("firezone", () => {});
 
 export function spawnEnemyShip(
   loc: vec2,

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -37,12 +37,16 @@ import { ColorDef } from "../color/color-ecs.js";
 import { AudioDef, Music } from "../audio/audio.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const EnemyCrewDef = EM.defineComponent("enemyCrew", () => {
-  return {
-    leftLegId: 0,
-    rightLegId: 0,
-  };
-});
+export const EnemyCrewDef = EM.defineComponent2(
+  "enemyCrew",
+  () => {
+    return {
+      leftLegId: 0,
+      rightLegId: 0,
+    };
+  },
+  (p) => p
+);
 
 export type EnemyCrew = Component<typeof EnemyCrewDef>;
 
@@ -379,7 +383,11 @@ export function breakEnemyShip(
   }
 }
 
-export const FireZoneDef = EM.defineComponent("firezone", () => {});
+export const FireZoneDef = EM.defineComponent2(
+  "firezone",
+  () => {},
+  (p) => p
+);
 
 export function spawnEnemyShip(
   loc: vec2,

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -52,22 +52,22 @@ export function createEnemyCrew(
   pos: vec3
 ): EntityW<[typeof EnemyCrewDef]> {
   const e = EM.new();
-  EM.ensureComponentOn(e, EnemyCrewDef);
-  EM.ensureComponentOn(e, PositionDef, pos);
-  EM.ensureComponentOn(e, RotationDef, quat.create());
+  EM.set(e, EnemyCrewDef);
+  EM.set(e, PositionDef, pos);
+  EM.set(e, RotationDef, quat.create());
   const torso = cloneMesh(allMeshes.cube.mesh);
   scaleMesh3(torso, V(0.75, 0.75, 0.4));
-  EM.ensureComponentOn(e, RenderableConstructDef, torso);
-  EM.ensureComponentOn(e, ColorDef, V(0.2, 0.0, 0));
-  EM.ensureComponentOn(e, PhysicsParentDef, parent);
+  EM.set(e, RenderableConstructDef, torso);
+  EM.set(e, ColorDef, V(0.2, 0.0, 0));
+  EM.set(e, PhysicsParentDef, parent);
 
   function makeLeg(x: number): Entity {
     const l = EM.new();
-    EM.ensureComponentOn(l, PositionDef, V(x, -1.75, 0));
-    EM.ensureComponentOn(l, RenderableConstructDef, allMeshes.cube.proto);
-    EM.ensureComponentOn(l, ScaleDef, V(0.1, 1.0, 0.1));
-    EM.ensureComponentOn(l, ColorDef, V(0.05, 0.05, 0.05));
-    EM.ensureComponentOn(l, PhysicsParentDef, e.id);
+    EM.set(l, PositionDef, V(x, -1.75, 0));
+    EM.set(l, RenderableConstructDef, allMeshes.cube.proto);
+    EM.set(l, ScaleDef, V(0.1, 1.0, 0.1));
+    EM.set(l, ColorDef, V(0.05, 0.05, 0.05));
+    EM.set(l, PhysicsParentDef, e.id);
     return l;
   }
   e.enemyCrew.leftLegId = makeLeg(-0.5).id;
@@ -131,29 +131,25 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
     dynamicComponents: [PositionDef, RotationDef],
     buildResources: [AllMeshesDef, MeDef],
     build: (e, res) => {
-      EM.ensureComponentOn(e, UVShipDef);
+      EM.set(e, UVShipDef);
       e.uvship.speed = e.enemyShipProps.speed;
 
-      EM.ensureComponentOn(e, ColorDef, ENEMY_SHIP_COLOR);
-      EM.ensureComponentOn(e, MotionSmoothingDef);
-      EM.ensureComponentOn(
-        e,
-        RenderableConstructDef,
-        res.allMeshes.enemyShip.mesh
-      );
+      EM.set(e, ColorDef, ENEMY_SHIP_COLOR);
+      EM.set(e, MotionSmoothingDef);
+      EM.set(e, RenderableConstructDef, res.allMeshes.enemyShip.mesh);
 
-      EM.ensureComponentOn(e, UVPosDef);
+      EM.set(e, UVPosDef);
       vec2.copy(e.uvPos, e.enemyShipProps.uvLoc);
-      EM.ensureComponentOn(e, UVDirDef);
+      EM.set(e, UVDirDef);
       vec2.copy(e.uvDir, e.enemyShipProps.uvDir);
 
-      EM.ensureComponentOn(e, PhysicsParentDef, e.enemyShipProps.parent);
+      EM.set(e, PhysicsParentDef, e.enemyShipProps.parent);
 
       // fire zone is local, not synced
       // TODO(@darzu): fire zone should probably be host-only
       const fireZone = EM.new();
       const fireZoneSize = 40;
-      EM.ensureComponentOn(fireZone, ColliderDef, {
+      EM.set(fireZone, ColliderDef, {
         solid: false,
         shape: "AABB",
         aabb: {
@@ -161,16 +157,16 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
           max: V(2, 2, fireZoneSize),
         },
       });
-      EM.ensureComponentOn(fireZone, PhysicsParentDef, e.id);
-      EM.ensureComponentOn(fireZone, PositionDef, V(0, 0, -fireZoneSize));
-      EM.ensureComponentOn(fireZone, FireZoneDef);
+      EM.set(fireZone, PhysicsParentDef, e.id);
+      EM.set(fireZone, PositionDef, V(0, 0, -fireZoneSize));
+      EM.set(fireZone, FireZoneDef);
       e.enemyShipLocal.fireZoneId = fireZone.id;
 
-      EM.ensureComponentOn(e, OnDeleteDef, () => {
+      EM.set(e, OnDeleteDef, () => {
         EM.ensureComponent(e.enemyShipLocal.fireZoneId, DeletedDef);
 
         const cannon = EM.findEntity(e.enemyShipLocal.childCannonId, [])!;
-        EM.ensureComponentOn(cannon, DeletedDef);
+        EM.set(cannon, DeletedDef);
 
         const enemy = EM.findEntity(e.enemyShipLocal.childEnemyId, [
           WorldFrameDef,
@@ -179,17 +175,17 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
           EnemyCrewDef,
         ]);
         if (enemy) {
-          EM.ensureComponent(enemy.id, LifetimeDef, 4000);
+          EM.set(enemy, LifetimeDef, 4000);
           EM.ensureComponent(enemy.enemyCrew.leftLegId, LifetimeDef, 4000);
           EM.ensureComponent(enemy.enemyCrew.rightLegId, LifetimeDef, 4000);
           EM.removeComponent(enemy.id, PhysicsParentDef);
           vec3.copy(enemy.position, enemy.world.position);
           quat.copy(enemy.rotation, enemy.world.rotation);
-          EM.ensureComponentOn(enemy, LinearVelocityDef, V(0, -0.002, 0));
+          EM.set(enemy, LinearVelocityDef, V(0, -0.002, 0));
         }
       });
 
-      EM.ensureComponentOn(e, ColliderDef, {
+      EM.set(e, ColliderDef, {
         shape: "AABB",
         // TODO(@darzu):
         solid: false,
@@ -198,20 +194,16 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
       });
 
       const cannon = EM.new();
-      EM.ensureComponentOn(
-        cannon,
-        RenderableConstructDef,
-        res.allMeshes.cannon.proto
-      );
-      EM.ensureComponentOn(cannon, PhysicsParentDef, e.id);
-      EM.ensureComponentOn(cannon, PositionDef, V(0, 2, 0));
+      EM.set(cannon, RenderableConstructDef, res.allMeshes.cannon.proto);
+      EM.set(cannon, PhysicsParentDef, e.id);
+      EM.set(cannon, PositionDef, V(0, 2, 0));
 
       const cannonRot = quat.create();
       const pitch = Math.PI * 0.08;
       // quat.rotateY(cannonRot, cannonRot, Math.PI * 0.5);
       // quat.rotateY(cannonRot, cannonRot, Math.PI * 0.5);
       quat.rotateX(cannonRot, pitch, cannonRot);
-      EM.ensureComponentOn(cannon, RotationDef, cannonRot);
+      EM.set(cannon, RotationDef, cannonRot);
       e.enemyShipLocal.childCannonId = cannon.id;
 
       // child enemy
@@ -219,7 +211,7 @@ export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
       e.enemyShipLocal.childEnemyId = en.id;
       if (e.authority.pid === res.me.pid) {
         // destroy after 1 minute
-        EM.ensureComponentOn(e, LifetimeDef, 1000 * 60);
+        EM.set(e, LifetimeDef, 1000 * 60);
       }
     },
   });
@@ -337,7 +329,7 @@ export function breakEnemyShip(
   enemyShipParts: GameMesh[],
   music: Music
 ) {
-  EM.ensureComponentOn(enemyShip, DeletedDef);
+  EM.set(enemyShip, DeletedDef);
 
   // TODO(@darzu): AUDIO. unify old and new audio system
   //music.playChords([3], "minor", 2.0, 5.0, -1);
@@ -346,10 +338,10 @@ export function breakEnemyShip(
     const pe = EM.new();
     // TODO(@darzu): use some sort of chunks particle system, we don't
     //  need entity ids for these.
-    EM.ensureComponentOn(pe, RenderableConstructDef, part.proto);
-    EM.ensureComponentOn(pe, ColorDef, ENEMY_SHIP_COLOR);
-    EM.ensureComponentOn(pe, RotationDef, quat.clone(enemyShip.rotation));
-    EM.ensureComponentOn(pe, PositionDef, vec3.clone(enemyShip.position));
+    EM.set(pe, RenderableConstructDef, part.proto);
+    EM.set(pe, ColorDef, ENEMY_SHIP_COLOR);
+    EM.set(pe, RotationDef, quat.clone(enemyShip.rotation));
+    EM.set(pe, PositionDef, vec3.clone(enemyShip.position));
     // EM.ensureComponentOn(pe, ColliderDef, {
     //   shape: "AABB",
     //   solid: false,
@@ -365,7 +357,7 @@ export function breakEnemyShip(
     vec3.normalize(vel, vel);
     vec3.add(vel, [0, -0.6, 0], vel);
     vec3.scale(vel, 0.005, vel);
-    EM.ensureComponentOn(pe, LinearVelocityDef, vel);
+    EM.set(pe, LinearVelocityDef, vel);
     const spin = V(
       Math.random() - 0.5,
       Math.random() - 0.5,
@@ -373,8 +365,8 @@ export function breakEnemyShip(
     );
     vec3.normalize(spin, spin);
     vec3.scale(spin, 0.001, spin);
-    EM.ensureComponentOn(pe, AngularVelocityDef, spin);
-    EM.ensureComponentOn(pe, LifetimeDef, 2000);
+    EM.set(pe, AngularVelocityDef, spin);
+    EM.set(pe, LifetimeDef, 2000);
   }
 }
 

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -342,7 +342,7 @@ export function breakEnemyShip(
     EM.set(pe, ColorDef, ENEMY_SHIP_COLOR);
     EM.set(pe, RotationDef, quat.clone(enemyShip.rotation));
     EM.set(pe, PositionDef, vec3.clone(enemyShip.position));
-    // EM.ensureComponentOn(pe, ColliderDef, {
+    // EM.set(pe, ColliderDef, {
     //   shape: "AABB",
     //   solid: false,
     //   aabb: part.aabb,

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -78,20 +78,30 @@ export function createEnemyCrew(
 export const { EnemyShipPropsDef, EnemyShipLocalDef, createEnemyShip } =
   defineNetEntityHelper({
     name: "enemyShip",
-    defaultProps: (
+    defaultProps: () => {
+      return {
+        uvLoc: vec2.fromValues(0, 0),
+        speed: 0.0,
+        wheelSpeed: 0.0,
+        uvDir: vec2.fromValues(1, 0),
+        parent: 0,
+      };
+    },
+    updateProps: (
+      p,
       uvLoc?: vec2,
       speed?: number,
       wheelSpeed?: number,
       uvDir?: vec2,
       parent?: number
     ) => {
-      return {
+      return Object.assign(p, {
         uvLoc: uvLoc ?? vec2.fromValues(0, 0),
         speed: speed ?? 0.0,
         wheelSpeed: wheelSpeed ?? 0.0,
         uvDir: uvDir ?? vec2.fromValues(1, 0),
         parent: parent ?? 0,
-      };
+      });
     },
     serializeProps: (c, buf) => {
       buf.writeVec2(c.uvLoc);

--- a/src/hyperspace/uv-enemy-ship.ts
+++ b/src/hyperspace/uv-enemy-ship.ts
@@ -37,7 +37,7 @@ import { ColorDef } from "../color/color-ecs.js";
 import { AudioDef, Music } from "../audio/audio.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const EnemyCrewDef = EM.defineComponent2(
+export const EnemyCrewDef = EM.defineComponent(
   "enemyCrew",
   () => {
     return {
@@ -383,7 +383,7 @@ export function breakEnemyShip(
   }
 }
 
-export const FireZoneDef = EM.defineComponent2(
+export const FireZoneDef = EM.defineComponent(
   "firezone",
   () => {},
   (p) => p

--- a/src/hyperspace/uv-ship.ts
+++ b/src/hyperspace/uv-ship.ts
@@ -6,15 +6,11 @@ import { AuthorityDef, MeDef } from "../net/components.js";
 import { UVPosDef, UVDirDef } from "../ocean/ocean.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const UVShipDef = EM.defineComponent(
-  "uvship",
-  () => {
-    return {
-      speed: 0,
-    };
-  },
-  (p) => p
-);
+export const UVShipDef = EM.defineComponent("uvship", () => {
+  return {
+    speed: 0,
+  };
+});
 
 export function registerUVShipSystems() {
   EM.addSystem(

--- a/src/hyperspace/uv-ship.ts
+++ b/src/hyperspace/uv-ship.ts
@@ -6,11 +6,15 @@ import { AuthorityDef, MeDef } from "../net/components.js";
 import { UVPosDef, UVDirDef } from "../ocean/ocean.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const UVShipDef = EM.defineComponent("uvship", () => {
-  return {
-    speed: 0,
-  };
-});
+export const UVShipDef = EM.defineComponent2(
+  "uvship",
+  () => {
+    return {
+      speed: 0,
+    };
+  },
+  (p) => p
+);
 
 export function registerUVShipSystems() {
   EM.addSystem(

--- a/src/hyperspace/uv-ship.ts
+++ b/src/hyperspace/uv-ship.ts
@@ -6,7 +6,7 @@ import { AuthorityDef, MeDef } from "../net/components.js";
 import { UVPosDef, UVDirDef } from "../ocean/ocean.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const UVShipDef = EM.defineComponent2(
+export const UVShipDef = EM.defineComponent(
   "uvship",
   () => {
     return {

--- a/src/hyperspace/uv-spawner.ts
+++ b/src/hyperspace/uv-spawner.ts
@@ -27,15 +27,15 @@ export interface Spawner {
   hasSpawned: boolean;
   childrenToRelease: Ref<[...typeof ChildCS]>[];
 }
-export const SpawnerDef = EM.defineComponent(
+export const SpawnerDef = EM.defineComponent2(
   "spawner",
-  function (s?: Partial<Spawner>): Spawner {
+  function (): Spawner {
     return {
       childrenToRelease: [],
       hasSpawned: false,
-      ...s,
     };
-  }
+  },
+  (p, s?: Partial<Spawner>) => Object.assign(p, s)
 );
 
 export function createSpawner(

--- a/src/hyperspace/uv-spawner.ts
+++ b/src/hyperspace/uv-spawner.ts
@@ -27,7 +27,7 @@ export interface Spawner {
   hasSpawned: boolean;
   childrenToRelease: Ref<[...typeof ChildCS]>[];
 }
-export const SpawnerDef = EM.defineComponent2(
+export const SpawnerDef = EM.defineComponent(
   "spawner",
   function (): Spawner {
     return {

--- a/src/hyperspace/uv-spawner.ts
+++ b/src/hyperspace/uv-spawner.ts
@@ -44,13 +44,13 @@ export function createSpawner(
   animate?: Partial<AnimateTo>
 ) {
   const e = EM.new();
-  EM.ensureComponentOn(e, SpawnerDef);
-  EM.ensureComponentOn(e, UVPosDef, uvPos);
-  EM.ensureComponentOn(e, UVDirDef, uvDir);
-  EM.ensureComponentOn(e, PositionDef);
-  EM.ensureComponentOn(e, RotationDef);
+  EM.set(e, SpawnerDef);
+  EM.set(e, UVPosDef, uvPos);
+  EM.set(e, UVDirDef, uvDir);
+  EM.set(e, PositionDef);
+  EM.set(e, RotationDef);
   // TODO(@darzu): put AuthorityDef and sync stuff on spawner
-  if (animate) EM.ensureComponentOn(e, AnimateToDef, animate);
+  if (animate) EM.set(e, AnimateToDef, animate);
   return e;
 }
 

--- a/src/input/controllable.ts
+++ b/src/input/controllable.ts
@@ -34,7 +34,7 @@ controllable:
   backspace -> delete obj
 */
 
-export const ControllableDef = EM.defineComponent2(
+export const ControllableDef = EM.defineComponent(
   "controllable",
   () => {
     return {

--- a/src/input/controllable.ts
+++ b/src/input/controllable.ts
@@ -34,31 +34,27 @@ controllable:
   backspace -> delete obj
 */
 
-export const ControllableDef = EM.defineComponent(
-  "controllable",
-  () => {
-    return {
-      speed: 0.0005,
-      sprintMul: 3,
-      gravity: 0.1 / 1000,
-      jumpSpeed: 0.003,
-      turnSpeed: 0.001,
-      requiresPointerLock: true,
-      modes: {
-        canFall: true,
-        canFly: true,
-        canSprint: true,
-        canJump: true,
-        canPitch: true,
-        canYaw: true,
-        // TODO(@darzu): this isn't clean...
-        canCameraYaw: false,
-        canMove: true,
-      },
-    };
-  },
-  (p) => p
-);
+export const ControllableDef = EM.defineComponent("controllable", () => {
+  return {
+    speed: 0.0005,
+    sprintMul: 3,
+    gravity: 0.1 / 1000,
+    jumpSpeed: 0.003,
+    turnSpeed: 0.001,
+    requiresPointerLock: true,
+    modes: {
+      canFall: true,
+      canFly: true,
+      canSprint: true,
+      canJump: true,
+      canPitch: true,
+      canYaw: true,
+      // TODO(@darzu): this isn't clean...
+      canCameraYaw: false,
+      canMove: true,
+    },
+  };
+});
 
 EM.addEagerInit([ControllableDef], [], [], () => {
   const steerVel = vec3.create();

--- a/src/input/controllable.ts
+++ b/src/input/controllable.ts
@@ -102,7 +102,7 @@ EM.addEagerInit([ControllableDef], [], [], () => {
           }
         }
 
-        EM.ensureComponentOn(c, LinearVelocityDef);
+        EM.set(c, LinearVelocityDef);
 
         if (modes.canFall)
           c.linearVelocity[1] -= c.controllable.gravity * res.time.dt;

--- a/src/input/controllable.ts
+++ b/src/input/controllable.ts
@@ -34,27 +34,31 @@ controllable:
   backspace -> delete obj
 */
 
-export const ControllableDef = EM.defineComponent("controllable", () => {
-  return {
-    speed: 0.0005,
-    sprintMul: 3,
-    gravity: 0.1 / 1000,
-    jumpSpeed: 0.003,
-    turnSpeed: 0.001,
-    requiresPointerLock: true,
-    modes: {
-      canFall: true,
-      canFly: true,
-      canSprint: true,
-      canJump: true,
-      canPitch: true,
-      canYaw: true,
-      // TODO(@darzu): this isn't clean...
-      canCameraYaw: false,
-      canMove: true,
-    },
-  };
-});
+export const ControllableDef = EM.defineComponent2(
+  "controllable",
+  () => {
+    return {
+      speed: 0.0005,
+      sprintMul: 3,
+      gravity: 0.1 / 1000,
+      jumpSpeed: 0.003,
+      turnSpeed: 0.001,
+      requiresPointerLock: true,
+      modes: {
+        canFall: true,
+        canFly: true,
+        canSprint: true,
+        canJump: true,
+        canPitch: true,
+        canYaw: true,
+        // TODO(@darzu): this isn't clean...
+        canCameraYaw: false,
+        canMove: true,
+      },
+    };
+  },
+  (p) => p
+);
 
 EM.addEagerInit([ControllableDef], [], [], () => {
   const steerVel = vec3.create();

--- a/src/input/interact.ts
+++ b/src/input/interact.ts
@@ -16,17 +16,25 @@ import { clearTint, setTint, TintsDef } from "../color/color-ecs.js";
 import { DeletedDef } from "../ecs/delete.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const InteractableDef = EM.defineComponent(
+export const InteractableDef = EM.defineComponent2(
   "interaction",
-  (colliderId?: number) => ({
+  () => ({
     // TODO(@darzu): components having pointers to entities should be
     //  handled better
     // TODO(@darzu): use Ref system
-    colliderId: colliderId || 0,
-  })
+    colliderId: 0,
+  }),
+  (p, colliderId?: number) => {
+    p.colliderId = colliderId ?? 0;
+    return p;
+  }
 );
 
-export const InRangeDef = EM.defineComponent("inRange", () => true);
+export const InRangeDef = EM.defineComponent2(
+  "inRange",
+  () => true,
+  (p) => p
+);
 
 const INTERACTION_TINT = V(0.1, 0.2, 0.1);
 const INTERACTION_TINT_NAME = "interaction";

--- a/src/input/interact.ts
+++ b/src/input/interact.ts
@@ -55,7 +55,7 @@ EM.addEagerInit([InteractableDef], [], [], () => {
         if (InRangeDef.isOn(interactable)) {
           EM.removeComponent(interactable.id, InRangeDef);
         }
-        EM.ensureComponentOn(interactable, TintsDef);
+        EM.set(interactable, TintsDef);
         clearTint(interactable.tints, INTERACTION_TINT_NAME);
       }
       // find an interactable within range of the player
@@ -65,8 +65,8 @@ EM.addEagerInit([InteractableDef], [], [], () => {
       if (interactableColliderId) {
         const interactable = interactablesMap.get(interactableColliderId)!;
         if (!DeletedDef.isOn(interactable)) {
-          EM.ensureComponentOn(interactable, InRangeDef);
-          EM.ensureComponentOn(interactable, TintsDef);
+          EM.set(interactable, InRangeDef);
+          EM.set(interactable, TintsDef);
           setTint(interactable.tints, INTERACTION_TINT_NAME, INTERACTION_TINT);
         }
       }

--- a/src/input/interact.ts
+++ b/src/input/interact.ts
@@ -16,25 +16,17 @@ import { clearTint, setTint, TintsDef } from "../color/color-ecs.js";
 import { DeletedDef } from "../ecs/delete.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const InteractableDef = EM.defineComponent(
+export const InteractableDef = EM.defineNonupdatableComponent(
   "interaction",
-  () => ({
+  (colliderId?: number) => ({
     // TODO(@darzu): components having pointers to entities should be
     //  handled better
     // TODO(@darzu): use Ref system
-    colliderId: 0,
-  }),
-  (p, colliderId?: number) => {
-    p.colliderId = colliderId ?? 0;
-    return p;
-  }
+    colliderId: colliderId || 0,
+  })
 );
 
-export const InRangeDef = EM.defineComponent(
-  "inRange",
-  () => true,
-  (p) => p
-);
+export const InRangeDef = EM.defineComponent("inRange", () => true);
 
 const INTERACTION_TINT = V(0.1, 0.2, 0.1);
 const INTERACTION_TINT_NAME = "interaction";

--- a/src/input/interact.ts
+++ b/src/input/interact.ts
@@ -16,7 +16,7 @@ import { clearTint, setTint, TintsDef } from "../color/color-ecs.js";
 import { DeletedDef } from "../ecs/delete.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const InteractableDef = EM.defineComponent2(
+export const InteractableDef = EM.defineComponent(
   "interaction",
   () => ({
     // TODO(@darzu): components having pointers to entities should be
@@ -30,7 +30,7 @@ export const InteractableDef = EM.defineComponent2(
   }
 );
 
-export const InRangeDef = EM.defineComponent2(
+export const InRangeDef = EM.defineComponent(
   "inRange",
   () => true,
   (p) => p

--- a/src/input/tool.ts
+++ b/src/input/tool.ts
@@ -17,7 +17,7 @@ import { InteractableDef, InRangeDef } from "./interact.js";
 import { Deserializer, Serializer } from "../utils/serialize.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ToolDef = EM.defineComponent2(
+export const ToolDef = EM.defineComponent(
   "tool",
   () => ({
     type: undefined as string | undefined,

--- a/src/input/tool.ts
+++ b/src/input/tool.ts
@@ -17,9 +17,16 @@ import { InteractableDef, InRangeDef } from "./interact.js";
 import { Deserializer, Serializer } from "../utils/serialize.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ToolDef = EM.defineComponent("tool", (type?: string) => ({
-  type,
-}));
+export const ToolDef = EM.defineComponent2(
+  "tool",
+  () => ({
+    type: undefined as string | undefined,
+  }),
+  (p, type?: string) => {
+    p.type = type;
+    return p;
+  }
+);
 
 export function registerToolSystems() {
   EM.addSystem(

--- a/src/input/tool.ts
+++ b/src/input/tool.ts
@@ -83,7 +83,7 @@ export function registerToolSystems() {
       // TODO(@darzu): add interact box
       // EM.removeComponent(tool.id, InteractableDef);
       vec3.set(0, 0, -1.5, tool.position);
-      EM.ensureComponentOn(tool, ScaleDef);
+      EM.set(tool, ScaleDef);
       vec3.copy(tool.scale, [0.5, 0.5, 0.5]);
       player.hsPlayer.tool = tool.id;
       if (ColliderDef.isOn(tool)) tool.collider.solid = false;
@@ -101,7 +101,7 @@ export function registerToolSystems() {
       // TODO(@darzu): add interact box
       // EM.addComponent(tool.id, InteractableDef);
       vec3.copy(tool.position, location);
-      EM.ensureComponentOn(tool, ScaleDef);
+      EM.set(tool, ScaleDef);
       vec3.copy(tool.scale, [1, 1, 1]);
       player.hsPlayer.tool = 0;
       if (ColliderDef.isOn(tool)) tool.collider.solid = true;

--- a/src/input/tool.ts
+++ b/src/input/tool.ts
@@ -17,15 +17,11 @@ import { InteractableDef, InRangeDef } from "./interact.js";
 import { Deserializer, Serializer } from "../utils/serialize.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ToolDef = EM.defineComponent(
+export const ToolDef = EM.defineNonupdatableComponent(
   "tool",
-  () => ({
-    type: undefined as string | undefined,
-  }),
-  (p, type?: string) => {
-    p.type = type;
-    return p;
-  }
+  (type?: string) => ({
+    type,
+  })
 );
 
 export function registerToolSystems() {

--- a/src/ld53/dock.ts
+++ b/src/ld53/dock.ts
@@ -31,21 +31,21 @@ export function createDock() {
 
   const dock = EM.new();
 
-  EM.ensureComponentOn(dock, PositionDef, V(0, 0, 0));
+  EM.set(dock, PositionDef, V(0, 0, 0));
 
-  EM.ensureComponentOn(dock, RenderableConstructDef, mesh);
-  EM.ensureComponentOn(dock, WoodStateDef, wood);
+  EM.set(dock, RenderableConstructDef, mesh);
+  EM.set(dock, WoodStateDef, wood);
   const timberHealth = createWoodHealth(wood);
-  EM.ensureComponentOn(dock, WoodHealthDef, timberHealth);
+  EM.set(dock, WoodHealthDef, timberHealth);
   const timberAABB = getAABBFromMesh(mesh);
   timberAABB.min[1] = -100;
   timberAABB.max[1] = 100;
-  EM.ensureComponentOn(dock, ColliderDef, {
+  EM.set(dock, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: timberAABB,
   });
-  EM.ensureComponentOn(dock, ColorDef, ENDESGA16.lightGreen);
+  EM.set(dock, ColorDef, ENDESGA16.lightGreen);
 
   return dock;
 }

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -222,11 +222,7 @@ export async function initLD53(hosting: boolean) {
   );
 
   // pirate test
-  const PirateDef = EM.defineComponent(
-    "pirate",
-    () => true,
-    (p) => p
-  );
+  const PirateDef = EM.defineComponent("pirate", () => true);
   const pirate = EM.new();
   EM.ensureComponentOn(
     pirate,
@@ -332,11 +328,7 @@ export async function initLD53(hosting: boolean) {
 
   // bouyancy
   if (!"true") {
-    const bouyDef = EM.defineComponent(
-      "bouy",
-      () => true,
-      (p) => p
-    );
+    const bouyDef = EM.defineComponent("bouy", () => true);
     const buoys: EntityW<[typeof PositionDef]>[] = [];
     for (let u = 0.4; u <= 0.6; u += 0.02) {
       for (let v = 0.4; v <= 0.6; v += 0.02) {

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -222,7 +222,11 @@ export async function initLD53(hosting: boolean) {
   );
 
   // pirate test
-  const PirateDef = EM.defineComponent("pirate", () => true);
+  const PirateDef = EM.defineComponent2(
+    "pirate",
+    () => true,
+    (p) => p
+  );
   const pirate = EM.new();
   EM.ensureComponentOn(
     pirate,
@@ -328,7 +332,11 @@ export async function initLD53(hosting: boolean) {
 
   // bouyancy
   if (!"true") {
-    const bouyDef = EM.defineComponent("bouy", () => true);
+    const bouyDef = EM.defineComponent2(
+      "bouy",
+      () => true,
+      (p) => p
+    );
     const buoys: EntityW<[typeof PositionDef]>[] = [];
     for (let u = 0.4; u <= 0.6; u += 0.02) {
       for (let v = 0.4; v <= 0.6; v += 0.02) {

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -254,7 +254,7 @@ export async function initLD53(hosting: boolean) {
   // skyMesh.tri.forEach((f) => vec3.reverse(f, f));
   const skyMesh = domeMesh;
   EM.set(sky, RenderableConstructDef, skyMesh, undefined, undefined, SKY_MASK);
-  // EM.ensureComponentOn(sky, ColorDef, V(0.9, 0.9, 0.9));
+  // EM.set(sky, ColorDef, V(0.9, 0.9, 0.9));
 
   // ocean
   // const oceanVertsPerWorldUnit = 0.02;
@@ -324,7 +324,7 @@ export async function initLD53(hosting: boolean) {
         const bouy = EM.new();
         EM.set(bouy, PositionDef, V(0, 0, 0));
         EM.set(bouy, UVPosDef, V(u + jitter(0.01), v + jitter(0.01)));
-        // EM.ensureComponentOn(bouy, ScaleDef, V(5, 5, 5));
+        // EM.set(bouy, ScaleDef, V(5, 5, 5));
         EM.set(bouy, bouyDef);
         EM.set(bouy, RenderableConstructDef, res.ld53Meshes.ball.proto);
         EM.set(bouy, ColorDef, ENDESGA16.lightGreen);
@@ -403,10 +403,10 @@ export async function initLD53(hosting: boolean) {
     const visible = false;
     EM.set(g, RenderableConstructDef, sphereMesh, visible);
     EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
-    // EM.ensureComponentOn(g, PositionDef, V(0, 0, 0));
-    // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+    // EM.set(g, PositionDef, V(0, 0, 0));
+    // EM.set(b2, PositionDef, [0, 0, -1.2]);
     EM.set(g, WorldFrameDef);
-    // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+    // EM.set(b2, PhysicsParentDef, g.id);
     EM.set(g, ColliderDef, {
       shape: "AABB",
       solid: false,
@@ -727,9 +727,9 @@ async function createPlayer() {
   EM.set(p, RenderableConstructDef, sphereMesh, visible);
   EM.set(p, ColorDef, V(0.1, 0.1, 0.1));
   EM.set(p, PositionDef, V(0, 0, 0));
-  // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+  // EM.set(b2, PositionDef, [0, 0, -1.2]);
   EM.set(p, WorldFrameDef);
-  // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+  // EM.set(b2, PhysicsParentDef, g.id);
   EM.set(p, ColliderDef, {
     shape: "AABB",
     solid: true,
@@ -792,7 +792,7 @@ async function resetLand() {
     EM.set(hm, RenderableConstructDef, terraMesh);
     EM.set(hm, PositionDef);
     // TODO(@darzu): maybe do a sable-like gradient accross the terrain, based on view dist or just uv?
-    // EM.ensureComponentOn(hm, ColorDef, V(0.4, 0.2, 0.2));
+    // EM.set(hm, ColorDef, V(0.4, 0.2, 0.2));
     EM.set(hm, ColorDef, ENDESGA16.lightGray);
     const hm2 = await EM.whenEntityHas(hm, RenderableDef);
     terraEnt = hm2;

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -144,6 +144,19 @@ export const LD53MeshesDef = XY.defineMeshSetResource(
   CubeMesh
 );
 
+const dbgGrid = [
+  //
+  [mapJfa._inputMaskTex, mapJfa._uvMaskTex],
+  //
+  // [mapJfa.voronoiTex, mapJfa.sdfTex],
+  // TODO(@darzu): FIX FOR CSM & texture arrays
+  [
+    { ptr: shadowDepthTextures, idx: 0 },
+    { ptr: shadowDepthTextures, idx: 1 },
+  ],
+];
+let dbgGridCompose = createGridComposePipelines(dbgGrid);
+
 export async function initLD53(hosting: boolean) {
   const res = await EM.whenResources(
     LD53MeshesDef,
@@ -153,19 +166,6 @@ export async function initLD53(hosting: boolean) {
     CameraDef,
     DevConsoleDef
   );
-
-  const dbgGrid = [
-    //
-    [mapJfa._inputMaskTex, mapJfa._uvMaskTex],
-    //
-    // [mapJfa.voronoiTex, mapJfa.sdfTex],
-    // TODO(@darzu): FIX FOR CSM & texture arrays
-    [
-      { ptr: shadowDepthTextures, idx: 0 },
-      { ptr: shadowDepthTextures, idx: 1 },
-    ],
-  ];
-  let dbgGridCompose = createGridComposePipelines(dbgGrid);
 
   // TODO(@darzu): HACK. these have to be set before the CY instantiator runs.
   outlineRender.fragOverrides!.lineWidth = 1.0;

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -222,7 +222,7 @@ export async function initLD53(hosting: boolean) {
   );
 
   // pirate test
-  const PirateDef = EM.defineComponent2(
+  const PirateDef = EM.defineComponent(
     "pirate",
     () => true,
     (p) => p
@@ -332,7 +332,7 @@ export async function initLD53(hosting: boolean) {
 
   // bouyancy
   if (!"true") {
-    const bouyDef = EM.defineComponent2(
+    const bouyDef = EM.defineComponent(
       "bouy",
       () => true,
       (p) => p

--- a/src/ld53/game-ld53.ts
+++ b/src/ld53/game-ld53.ts
@@ -207,31 +207,27 @@ export async function initLD53(hosting: boolean) {
 
   // Sun
   const sunlight = EM.new();
-  EM.ensureComponentOn(sunlight, PointLightDef);
+  EM.set(sunlight, PointLightDef);
   // sunlight.pointLight.constant = 1.0;
   sunlight.pointLight.constant = 1.0;
   sunlight.pointLight.linear = 0.0;
   sunlight.pointLight.quadratic = 0.0;
   vec3.copy(sunlight.pointLight.ambient, [0.2, 0.2, 0.2]);
   vec3.copy(sunlight.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sunlight, PositionDef, V(50, 300, 10));
-  EM.ensureComponentOn(
-    sunlight,
-    RenderableConstructDef,
-    res.ld53Meshes.ball.proto
-  );
+  EM.set(sunlight, PositionDef, V(50, 300, 10));
+  EM.set(sunlight, RenderableConstructDef, res.ld53Meshes.ball.proto);
 
   // pirate test
   const PirateDef = EM.defineComponent("pirate", () => true);
   const pirate = EM.new();
-  EM.ensureComponentOn(
+  EM.set(
     pirate,
     RiggedRenderableConstructDef,
     res.ld53Meshes.pirate.mesh as RiggedMesh
   );
-  EM.ensureComponentOn(pirate, PositionDef, V(50, 80, 10));
-  EM.ensureComponentOn(pirate, PirateDef);
-  EM.ensureComponentOn(pirate, PoseDef, 0);
+  EM.set(pirate, PositionDef, V(50, 80, 10));
+  EM.set(pirate, PirateDef);
+  EM.set(pirate, PoseDef, 0);
   pirate.pose.repeat = [
     { pose: 1, t: 500 },
     { pose: 0, t: 500 },
@@ -251,20 +247,13 @@ export async function initLD53(hosting: boolean) {
   const SKY_HALFSIZE = 1000;
   const domeMesh = makeDome(16, 8, SKY_HALFSIZE);
   const sky = EM.new();
-  EM.ensureComponentOn(sky, PositionDef, V(0, -100, 0));
+  EM.set(sky, PositionDef, V(0, -100, 0));
   // const skyMesh = cloneMesh(res.allMeshes.cube.mesh);
   // skyMesh.pos.forEach((p) => vec3.scale(p, SKY_HALFSIZE, p));
   // skyMesh.quad.forEach((f) => vec4.reverse(f, f));
   // skyMesh.tri.forEach((f) => vec3.reverse(f, f));
   const skyMesh = domeMesh;
-  EM.ensureComponentOn(
-    sky,
-    RenderableConstructDef,
-    skyMesh,
-    undefined,
-    undefined,
-    SKY_MASK
-  );
+  EM.set(sky, RenderableConstructDef, skyMesh, undefined, undefined, SKY_MASK);
   // EM.ensureComponentOn(sky, ColorDef, V(0.9, 0.9, 0.9));
 
   // ocean
@@ -319,7 +308,7 @@ export async function initLD53(hosting: boolean) {
 
   const ship = await createShip();
 
-  EM.ensureComponentOn(ship, ShipHealthDef);
+  EM.set(ship, ShipHealthDef);
 
   // move down
   // ship.position[2] = -WORLD_SIZE * 0.5 * 0.6;
@@ -333,20 +322,12 @@ export async function initLD53(hosting: boolean) {
     for (let u = 0.4; u <= 0.6; u += 0.02) {
       for (let v = 0.4; v <= 0.6; v += 0.02) {
         const bouy = EM.new();
-        EM.ensureComponentOn(bouy, PositionDef, V(0, 0, 0));
-        EM.ensureComponentOn(
-          bouy,
-          UVPosDef,
-          V(u + jitter(0.01), v + jitter(0.01))
-        );
+        EM.set(bouy, PositionDef, V(0, 0, 0));
+        EM.set(bouy, UVPosDef, V(u + jitter(0.01), v + jitter(0.01)));
         // EM.ensureComponentOn(bouy, ScaleDef, V(5, 5, 5));
-        EM.ensureComponentOn(bouy, bouyDef);
-        EM.ensureComponentOn(
-          bouy,
-          RenderableConstructDef,
-          res.ld53Meshes.ball.proto
-        );
-        EM.ensureComponentOn(bouy, ColorDef, ENDESGA16.lightGreen);
+        EM.set(bouy, bouyDef);
+        EM.set(bouy, RenderableConstructDef, res.ld53Meshes.ball.proto);
+        EM.set(bouy, ColorDef, ENDESGA16.lightGreen);
         buoys.push(bouy);
       }
     }
@@ -420,13 +401,13 @@ export async function initLD53(hosting: boolean) {
     g.controllable.sprintMul = 15;
     const sphereMesh = cloneMesh(res.ld53Meshes.ball.mesh);
     const visible = false;
-    EM.ensureComponentOn(g, RenderableConstructDef, sphereMesh, visible);
-    EM.ensureComponentOn(g, ColorDef, V(0.1, 0.1, 0.1));
+    EM.set(g, RenderableConstructDef, sphereMesh, visible);
+    EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
     // EM.ensureComponentOn(g, PositionDef, V(0, 0, 0));
     // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-    EM.ensureComponentOn(g, WorldFrameDef);
+    EM.set(g, WorldFrameDef);
     // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-    EM.ensureComponentOn(g, ColliderDef, {
+    EM.set(g, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: res.ld53Meshes.ball.aabb,
@@ -644,13 +625,9 @@ export async function initLD53(hosting: boolean) {
     // world gizmo
     const gizmoMesh = await GizmoMesh.gameMesh();
     const worldGizmo = EM.new();
-    EM.ensureComponentOn(
-      worldGizmo,
-      PositionDef,
-      V(-WORLD_HEIGHT / 2, 0, -WORLD_WIDTH / 2)
-    );
-    EM.ensureComponentOn(worldGizmo, ScaleDef, V(100, 100, 100));
-    EM.ensureComponentOn(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
+    EM.set(worldGizmo, PositionDef, V(-WORLD_HEIGHT / 2, 0, -WORLD_WIDTH / 2));
+    EM.set(worldGizmo, ScaleDef, V(100, 100, 100));
+    EM.set(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
   }
 
   // // debugging createGraph3D
@@ -726,19 +703,19 @@ export async function initLD53(hosting: boolean) {
 async function createPlayer() {
   const { ld53Meshes, me } = await EM.whenResources(LD53MeshesDef, MeDef);
   const p = EM.new();
-  EM.ensureComponentOn(p, ControllableDef);
+  EM.set(p, ControllableDef);
   p.controllable.modes.canFall = false;
   p.controllable.modes.canJump = false;
   // g.controllable.modes.canYaw = true;
   // g.controllable.modes.canPitch = true;
-  EM.ensureComponentOn(p, CameraFollowDef, 1);
+  EM.set(p, CameraFollowDef, 1);
   // setCameraFollowPosition(p, "firstPerson");
   // setCameraFollowPosition(p, "thirdPerson");
-  EM.ensureComponentOn(p, PositionDef);
-  EM.ensureComponentOn(p, RotationDef);
+  EM.set(p, PositionDef);
+  EM.set(p, RotationDef);
   // quat.rotateY(g.rotation, quat.IDENTITY, (-5 * Math.PI) / 8);
   // quat.rotateX(g.cameraFollow.rotationOffset, quat.IDENTITY, -Math.PI / 8);
-  EM.ensureComponentOn(p, LinearVelocityDef);
+  EM.set(p, LinearVelocityDef);
 
   vec3.copy(p.position, [0, 1, -1.2]);
   quat.setAxisAngle([0.0, -1.0, 0.0], 1.62, p.rotation);
@@ -747,13 +724,13 @@ async function createPlayer() {
   p.controllable.sprintMul = 10;
   const sphereMesh = cloneMesh(ld53Meshes.ball.mesh);
   const visible = true;
-  EM.ensureComponentOn(p, RenderableConstructDef, sphereMesh, visible);
-  EM.ensureComponentOn(p, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(p, PositionDef, V(0, 0, 0));
+  EM.set(p, RenderableConstructDef, sphereMesh, visible);
+  EM.set(p, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(p, PositionDef, V(0, 0, 0));
   // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-  EM.ensureComponentOn(p, WorldFrameDef);
+  EM.set(p, WorldFrameDef);
   // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-  EM.ensureComponentOn(p, ColliderDef, {
+  EM.set(p, ColliderDef, {
     shape: "AABB",
     solid: true,
     aabb: ld53Meshes.ball.aabb,
@@ -766,9 +743,9 @@ async function createPlayer() {
   p.cameraFollow.pitchOffset = -0.593;
 
   EM.ensureResource(LocalHsPlayerDef, p.id);
-  EM.ensureComponentOn(p, HsPlayerDef);
-  EM.ensureComponentOn(p, AuthorityDef, me.pid);
-  EM.ensureComponentOn(p, PhysicsParentDef);
+  EM.set(p, HsPlayerDef);
+  EM.set(p, AuthorityDef, me.pid);
+  EM.set(p, PhysicsParentDef);
   return p;
 }
 
@@ -812,11 +789,11 @@ async function resetLand() {
 
     // console.log(`heightmap minY: ${minY}`);
     const hm = EM.new();
-    EM.ensureComponentOn(hm, RenderableConstructDef, terraMesh);
-    EM.ensureComponentOn(hm, PositionDef);
+    EM.set(hm, RenderableConstructDef, terraMesh);
+    EM.set(hm, PositionDef);
     // TODO(@darzu): maybe do a sable-like gradient accross the terrain, based on view dist or just uv?
     // EM.ensureComponentOn(hm, ColorDef, V(0.4, 0.2, 0.2));
-    EM.ensureComponentOn(hm, ColorDef, ENDESGA16.lightGray);
+    EM.set(hm, ColorDef, ENDESGA16.lightGray);
     const hm2 = await EM.whenEntityHas(hm, RenderableDef);
     terraEnt = hm2;
   } else {

--- a/src/ld53/ship-health.ts
+++ b/src/ld53/ship-health.ts
@@ -39,15 +39,11 @@ import { Phase } from "../ecs/sys-phase.js";
 
 const MIN_HEALTH_PERCENT = 0.7;
 
-export const ShipHealthDef = EM.defineComponent(
-  "shipHealth",
-  () => ({
-    needsUpdate: false,
-    health: 1,
-    startingTimberHealth: 0,
-  }),
-  (p) => p
-);
+export const ShipHealthDef = EM.defineComponent("shipHealth", () => ({
+  needsUpdate: false,
+  health: 1,
+  startingTimberHealth: 0,
+}));
 
 function getCurrentHealth(timberHealth: Component<typeof WoodHealthDef>) {
   let health = 0;

--- a/src/ld53/ship-health.ts
+++ b/src/ld53/ship-health.ts
@@ -39,11 +39,15 @@ import { Phase } from "../ecs/sys-phase.js";
 
 const MIN_HEALTH_PERCENT = 0.7;
 
-export const ShipHealthDef = EM.defineComponent("shipHealth", () => ({
-  needsUpdate: false,
-  health: 1,
-  startingTimberHealth: 0,
-}));
+export const ShipHealthDef = EM.defineComponent2(
+  "shipHealth",
+  () => ({
+    needsUpdate: false,
+    health: 1,
+    startingTimberHealth: 0,
+  }),
+  (p) => p
+);
 
 function getCurrentHealth(timberHealth: Component<typeof WoodHealthDef>) {
   let health = 0;

--- a/src/ld53/ship-health.ts
+++ b/src/ld53/ship-health.ts
@@ -39,7 +39,7 @@ import { Phase } from "../ecs/sys-phase.js";
 
 const MIN_HEALTH_PERCENT = 0.7;
 
-export const ShipHealthDef = EM.defineComponent2(
+export const ShipHealthDef = EM.defineComponent(
   "shipHealth",
   () => ({
     needsUpdate: false,

--- a/src/ld53/ship.ts
+++ b/src/ld53/ship.ts
@@ -45,7 +45,7 @@ import {
 } from "../cannons/cannon.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ShipDef = EM.defineComponent2(
+export const ShipDef = EM.defineComponent(
   "ld52ship",
   () => ({
     mast: createRef(0, [MastDef, RotationDef]),
@@ -239,7 +239,7 @@ EM.addSystem(
   }
 );
 
-export const RudderDef = EM.defineComponent2(
+export const RudderDef = EM.defineComponent(
   "rudder",
   () => true,
   (p) => p

--- a/src/ld53/ship.ts
+++ b/src/ld53/ship.ts
@@ -120,7 +120,7 @@ export async function createShip() {
       aabb,
     })),
   };
-  // EM.ensureComponentOn(ent, ColliderDef, {
+  // EM.set(ent, ColliderDef, {
   //   shape: "AABB",
   //   solid: false,
   //   aabb: timberAABB,
@@ -129,7 +129,7 @@ export async function createShip() {
   EM.set(ent, PositionDef, V(0, 0, 0));
   EM.set(ent, RotationDef);
   EM.set(ent, LinearVelocityDef);
-  // EM.ensureComponentOn(ent, ColorDef, V(0.5, 0.3, 0.1));
+  // EM.set(ent, ColorDef, V(0.5, 0.3, 0.1));
   EM.set(ent, ColorDef, V(0, 0, 0)); // painted by individual planks!
 
   const mast = await createMast();
@@ -151,10 +151,10 @@ export async function createShip() {
   // make debug gizmo
   // TODO(@darzu): would be nice to have as a little helper function?
   // const gizmo = EM.new();
-  // EM.ensureComponentOn(gizmo, PositionDef, V(0, 20, 0));
-  // EM.ensureComponentOn(gizmo, ScaleDef, V(10, 10, 10));
-  // EM.ensureComponentOn(gizmo, PhysicsParentDef, ent.id);
-  // EM.ensureComponentOn(gizmo, RenderableConstructDef, res.allMeshes.gizmo.proto);
+  // EM.set(gizmo, PositionDef, V(0, 20, 0));
+  // EM.set(gizmo, ScaleDef, V(10, 10, 10));
+  // EM.set(gizmo, PhysicsParentDef, ent.id);
+  // EM.set(gizmo, RenderableConstructDef, res.allMeshes.gizmo.proto);
 
   // addGizmoChild(ent, 10);
 
@@ -243,7 +243,7 @@ async function createRudder() {
   const ent = EM.new();
   EM.set(ent, RudderDef);
   EM.set(ent, RenderableConstructDef, rudderMesh.proto);
-  // EM.ensureComponentOn(ent, ColorDef, V(0.2, 0.1, 0.05));
+  // EM.set(ent, ColorDef, V(0.2, 0.1, 0.05));
   EM.set(ent, ColorDef, ENDESGA16.midBrown);
   EM.set(ent, PositionDef);
   EM.set(ent, RotationDef);

--- a/src/ld53/ship.ts
+++ b/src/ld53/ship.ts
@@ -89,13 +89,13 @@ export async function createShip() {
 
   const homeShip = createHomeShip();
 
-  EM.ensureComponentOn(
+  EM.set(
     ent,
     RenderableConstructDef,
     homeShip.timberMesh
     // res.allMeshes.ship_small.proto
   );
-  EM.ensureComponentOn(ent, WoodStateDef, homeShip.timberState);
+  EM.set(ent, WoodStateDef, homeShip.timberState);
   // EM.set(ent, ColliderDef, {
   //   shape: "AABB",
   //   solid: true,
@@ -103,7 +103,7 @@ export async function createShip() {
   // });
 
   const timberHealth = createWoodHealth(homeShip.timberState);
-  EM.ensureComponentOn(ent, WoodHealthDef, timberHealth);
+  EM.set(ent, WoodHealthDef, timberHealth);
 
   // const timberAABB = getAABBFromMesh(homeShip.timberMesh);
   // console.log("ship size:");
@@ -125,23 +125,23 @@ export async function createShip() {
   //   solid: false,
   //   aabb: timberAABB,
   // });
-  EM.ensureComponentOn(ent, ColliderDef, mc);
-  EM.ensureComponentOn(ent, PositionDef, V(0, 0, 0));
-  EM.ensureComponentOn(ent, RotationDef);
-  EM.ensureComponentOn(ent, LinearVelocityDef);
+  EM.set(ent, ColliderDef, mc);
+  EM.set(ent, PositionDef, V(0, 0, 0));
+  EM.set(ent, RotationDef);
+  EM.set(ent, LinearVelocityDef);
   // EM.ensureComponentOn(ent, ColorDef, V(0.5, 0.3, 0.1));
-  EM.ensureComponentOn(ent, ColorDef, V(0, 0, 0)); // painted by individual planks!
+  EM.set(ent, ColorDef, V(0, 0, 0)); // painted by individual planks!
 
   const mast = await createMast();
-  EM.ensureComponentOn(mast, PhysicsParentDef, ent.id);
+  EM.set(mast, PhysicsParentDef, ent.id);
 
   const sock = createSock(2.0);
-  EM.ensureComponentOn(sock, PhysicsParentDef, ent.id);
+  EM.set(sock, PhysicsParentDef, ent.id);
   sock.position[1] =
     mast.position[1] + (mast.collider as AABBCollider).aabb.max[1];
 
   const rudder = await createRudder();
-  EM.ensureComponentOn(rudder, PhysicsParentDef, ent.id);
+  EM.set(rudder, PhysicsParentDef, ent.id);
   // console.log("setting position");
   vec3.set(0, 4, -25, rudder.position);
   // console.log(`rudder: ${rudder.id}`);
@@ -179,7 +179,7 @@ export async function createShip() {
   vec3.copy(cannonL.color, ENDESGA16.darkGray);
 
   // NOTE: we need to build the ship all at once so we don't have dangling references
-  EM.ensureComponentOn(ent, ShipDef);
+  EM.set(ent, ShipDef);
   ent.ld52ship.mast = createRef(mast);
   ent.ld52ship.rudder = createRef(rudder);
   ent.ld52ship.cannonR = createRef(cannonR);
@@ -241,17 +241,17 @@ async function createRudder() {
   const res = await EM.whenResources(MeDef);
   const rudderMesh = await RudderPrimMesh.gameMesh();
   const ent = EM.new();
-  EM.ensureComponentOn(ent, RudderDef);
-  EM.ensureComponentOn(ent, RenderableConstructDef, rudderMesh.proto);
+  EM.set(ent, RudderDef);
+  EM.set(ent, RenderableConstructDef, rudderMesh.proto);
   // EM.ensureComponentOn(ent, ColorDef, V(0.2, 0.1, 0.05));
-  EM.ensureComponentOn(ent, ColorDef, ENDESGA16.midBrown);
-  EM.ensureComponentOn(ent, PositionDef);
-  EM.ensureComponentOn(ent, RotationDef);
-  EM.ensureComponentOn(ent, AuthorityDef, res.me.pid);
+  EM.set(ent, ColorDef, ENDESGA16.midBrown);
+  EM.set(ent, PositionDef);
+  EM.set(ent, RotationDef);
+  EM.set(ent, AuthorityDef, res.me.pid);
   const interactBox = EM.new();
-  EM.ensureComponentOn(interactBox, PhysicsParentDef, ent.id);
-  EM.ensureComponentOn(interactBox, PositionDef);
-  EM.ensureComponentOn(interactBox, ColliderDef, {
+  EM.set(interactBox, PhysicsParentDef, ent.id);
+  EM.set(interactBox, PositionDef);
+  EM.set(interactBox, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: {

--- a/src/ld53/ship.ts
+++ b/src/ld53/ship.ts
@@ -45,34 +45,38 @@ import {
 } from "../cannons/cannon.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ShipDef = EM.defineComponent("ld52ship", () => ({
-  mast: createRef(0, [MastDef, RotationDef]),
-  rudder: createRef(0, [
-    RudderDef,
-    YawPitchDef,
-    TurretDef,
-    // CameraFollowDef,
-    AuthorityDef,
-    PositionDef,
-  ]),
-  cannonR: createRef(0, [
-    CannonLocalDef,
-    YawPitchDef,
-    TurretDef,
-    // CameraFollowDef,
-    AuthorityDef,
-    PositionDef,
-  ]),
-  cannonL: createRef(0, [
-    CannonLocalDef,
-    YawPitchDef,
-    TurretDef,
-    // CameraFollowDef,
-    AuthorityDef,
-    PositionDef,
-  ]),
-  cuttingEnabled: true,
-}));
+export const ShipDef = EM.defineComponent2(
+  "ld52ship",
+  () => ({
+    mast: createRef(0, [MastDef, RotationDef]),
+    rudder: createRef(0, [
+      RudderDef,
+      YawPitchDef,
+      TurretDef,
+      // CameraFollowDef,
+      AuthorityDef,
+      PositionDef,
+    ]),
+    cannonR: createRef(0, [
+      CannonLocalDef,
+      YawPitchDef,
+      TurretDef,
+      // CameraFollowDef,
+      AuthorityDef,
+      PositionDef,
+    ]),
+    cannonL: createRef(0, [
+      CannonLocalDef,
+      YawPitchDef,
+      TurretDef,
+      // CameraFollowDef,
+      AuthorityDef,
+      PositionDef,
+    ]),
+    cuttingEnabled: true,
+  }),
+  (p) => p
+);
 
 const MIN_SPEED = 0.0001;
 const MAX_SPEED = 10.0;
@@ -235,7 +239,11 @@ EM.addSystem(
   }
 );
 
-export const RudderDef = EM.defineComponent("rudder", () => true);
+export const RudderDef = EM.defineComponent2(
+  "rudder",
+  () => true,
+  (p) => p
+);
 
 async function createRudder() {
   const res = await EM.whenResources(MeDef);

--- a/src/ld53/ship.ts
+++ b/src/ld53/ship.ts
@@ -45,38 +45,34 @@ import {
 } from "../cannons/cannon.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const ShipDef = EM.defineComponent(
-  "ld52ship",
-  () => ({
-    mast: createRef(0, [MastDef, RotationDef]),
-    rudder: createRef(0, [
-      RudderDef,
-      YawPitchDef,
-      TurretDef,
-      // CameraFollowDef,
-      AuthorityDef,
-      PositionDef,
-    ]),
-    cannonR: createRef(0, [
-      CannonLocalDef,
-      YawPitchDef,
-      TurretDef,
-      // CameraFollowDef,
-      AuthorityDef,
-      PositionDef,
-    ]),
-    cannonL: createRef(0, [
-      CannonLocalDef,
-      YawPitchDef,
-      TurretDef,
-      // CameraFollowDef,
-      AuthorityDef,
-      PositionDef,
-    ]),
-    cuttingEnabled: true,
-  }),
-  (p) => p
-);
+export const ShipDef = EM.defineComponent("ld52ship", () => ({
+  mast: createRef(0, [MastDef, RotationDef]),
+  rudder: createRef(0, [
+    RudderDef,
+    YawPitchDef,
+    TurretDef,
+    // CameraFollowDef,
+    AuthorityDef,
+    PositionDef,
+  ]),
+  cannonR: createRef(0, [
+    CannonLocalDef,
+    YawPitchDef,
+    TurretDef,
+    // CameraFollowDef,
+    AuthorityDef,
+    PositionDef,
+  ]),
+  cannonL: createRef(0, [
+    CannonLocalDef,
+    YawPitchDef,
+    TurretDef,
+    // CameraFollowDef,
+    AuthorityDef,
+    PositionDef,
+  ]),
+  cuttingEnabled: true,
+}));
 
 const MIN_SPEED = 0.0001;
 const MAX_SPEED = 10.0;
@@ -239,11 +235,7 @@ EM.addSystem(
   }
 );
 
-export const RudderDef = EM.defineComponent(
-  "rudder",
-  () => true,
-  (p) => p
-);
+export const RudderDef = EM.defineComponent("rudder", () => true);
 
 async function createRudder() {
   const res = await EM.whenResources(MeDef);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ const ALL_GAMES = [
   "ld53",
   "mp",
 ] as const;
-const GAME: (typeof ALL_GAMES)[number] = "ld53";
+const GAME: (typeof ALL_GAMES)[number] = "mp";
 
 // Run simulation with a fixed timestep @ 60hz
 const TIMESTEP = 1000 / 60;

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ const ALL_GAMES = [
   "gjk",
   "rebound", // broken-ish
   "shipyard",
-  "grass",
+  "grass", // broken-ish
   "font",
   "hyperspace",
   "cloth", // broken-ish
@@ -54,7 +54,7 @@ const ALL_GAMES = [
   "ld53",
   "mp",
 ] as const;
-const GAME: (typeof ALL_GAMES)[number] = "mp";
+const GAME: (typeof ALL_GAMES)[number] = "ld53";
 
 // Run simulation with a fixed timestep @ 60hz
 const TIMESTEP = 1000 / 60;

--- a/src/meshes/game-modeling.ts
+++ b/src/meshes/game-modeling.ts
@@ -59,8 +59,8 @@ export async function initModelingGame() {
   const sun = EM.new();
   EM.set(sun, PointLightDef);
   EM.set(sun, ColorDef, V(1, 1, 1));
-  // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
-  // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
+  // EM.set(sun, PositionDef, V(100, 100, 0));
+  // EM.set(sun, PositionDef, V(-10, 10, 10));
   EM.set(sun, PositionDef, V(100, 100, 100));
   EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
   EM.set(sun, RenderableConstructDef, allMeshes.cube.proto);
@@ -100,11 +100,11 @@ export async function initModelingGame() {
   // objects
   const obj = EM.new();
   const ship = createHomeShip();
-  // EM.ensureComponentOn(obj, RenderableConstructDef, allMeshes.ship_small.proto);
+  // EM.set(obj, RenderableConstructDef, allMeshes.ship_small.proto);
   EM.set(obj, RenderableConstructDef, ship.timberMesh);
   EM.set(obj, PositionDef, V(0, 0, 0));
   EM.set(obj, ColorDef, ENDESGA16.midBrown);
-  // EM.ensureComponentOn(obj, AngularVelocityDef, V(0.001, 0.00013, 0.00017));
+  // EM.set(obj, AngularVelocityDef, V(0.001, 0.00013, 0.00017));
 
   const txt = await EM.whenResources(TextDef);
   txt.text.lowerText = `m: toggle modeler, b: new box, shift-b: export, x/y/z: move, shift-x/y/z: scale`;

--- a/src/meshes/game-modeling.ts
+++ b/src/meshes/game-modeling.ts
@@ -57,31 +57,31 @@ export async function initModelingGame() {
 
   // light
   const sun = EM.new();
-  EM.ensureComponentOn(sun, PointLightDef);
-  EM.ensureComponentOn(sun, ColorDef, V(1, 1, 1));
+  EM.set(sun, PointLightDef);
+  EM.set(sun, ColorDef, V(1, 1, 1));
   // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
   // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
-  EM.ensureComponentOn(sun, PositionDef, V(100, 100, 100));
-  EM.ensureComponentOn(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
-  EM.ensureComponentOn(sun, RenderableConstructDef, allMeshes.cube.proto);
+  EM.set(sun, PositionDef, V(100, 100, 100));
+  EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
+  EM.set(sun, RenderableConstructDef, allMeshes.cube.proto);
   sun.pointLight.constant = 1.0;
   sun.pointLight.linear = 0.0;
   sun.pointLight.quadratic = 0.0;
   vec3.copy(sun.pointLight.ambient, [0.2, 0.2, 0.2]);
   vec3.copy(sun.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sun, PositionDef, V(50, 300, 10));
+  EM.set(sun, PositionDef, V(50, 300, 10));
 
   // ground
   const ground = EM.new();
-  EM.ensureComponentOn(ground, RenderableConstructDef, allMeshes.hex.proto);
-  EM.ensureComponentOn(ground, ColorDef, ENDESGA16.blue);
-  EM.ensureComponentOn(ground, PositionDef, V(0, -10, 0));
-  EM.ensureComponentOn(ground, ScaleDef, V(10, 10, 10));
+  EM.set(ground, RenderableConstructDef, allMeshes.hex.proto);
+  EM.set(ground, ColorDef, ENDESGA16.blue);
+  EM.set(ground, PositionDef, V(0, -10, 0));
+  EM.set(ground, ScaleDef, V(10, 10, 10));
 
   // avatar
   const g = createGhost();
   g.position[1] = 5;
-  EM.ensureComponentOn(g, RenderableConstructDef, allMeshes.ball.proto);
+  EM.set(g, RenderableConstructDef, allMeshes.ball.proto);
   // vec3.copy(g.position, [2.44, 6.81, 0.96]);
   // quat.copy(g.rotation, [0.0, 0.61, 0.0, 0.79]);
   // g.cameraFollow.pitchOffset = -0.553;
@@ -93,17 +93,17 @@ export async function initModelingGame() {
 
   // origin
   const origin = EM.new();
-  EM.ensureComponentOn(origin, RenderableConstructDef, allMeshes.ball.proto);
-  EM.ensureComponentOn(origin, PositionDef, V(0, 0, 0));
-  EM.ensureComponentOn(origin, ColorDef, ENDESGA16.lightGreen);
+  EM.set(origin, RenderableConstructDef, allMeshes.ball.proto);
+  EM.set(origin, PositionDef, V(0, 0, 0));
+  EM.set(origin, ColorDef, ENDESGA16.lightGreen);
 
   // objects
   const obj = EM.new();
   const ship = createHomeShip();
   // EM.ensureComponentOn(obj, RenderableConstructDef, allMeshes.ship_small.proto);
-  EM.ensureComponentOn(obj, RenderableConstructDef, ship.timberMesh);
-  EM.ensureComponentOn(obj, PositionDef, V(0, 0, 0));
-  EM.ensureComponentOn(obj, ColorDef, ENDESGA16.midBrown);
+  EM.set(obj, RenderableConstructDef, ship.timberMesh);
+  EM.set(obj, PositionDef, V(0, 0, 0));
+  EM.set(obj, ColorDef, ENDESGA16.midBrown);
   // EM.ensureComponentOn(obj, AngularVelocityDef, V(0.001, 0.00013, 0.00017));
 
   const txt = await EM.whenResources(TextDef);

--- a/src/meshes/mesh.ts
+++ b/src/meshes/mesh.ts
@@ -502,6 +502,17 @@ export function normalizeMesh(inM: RawMesh): Mesh {
   };
 }
 
+export function createEmptyMesh(dbgName: string) {
+  let mesh: RawMesh = {
+    dbgName,
+    pos: [],
+    tri: [],
+    quad: [],
+    colors: [],
+  };
+  return mesh;
+}
+
 export function getAABBFromMesh(m: RawMesh): AABB {
   return getAABBFromPositions(createAABB(), m.pos);
 }

--- a/src/meshes/modeler.ts
+++ b/src/meshes/modeler.ts
@@ -82,7 +82,7 @@ function registerObjClicker() {
           // increase green
           const e = EM.findEntity(firstHit.id, [ColorDef]);
           if (e) {
-            EM.ensureComponentOn(e, TintsDef);
+            EM.set(e, TintsDef);
             e.tints.set("select", V(0, 0.2, 0));
             // e.color[1] += 0.1;
           }
@@ -144,29 +144,17 @@ function registerAABBBuilder() {
             ScaleDef,
           ]);
 
-          EM.ensureComponentOn(b, ModelBoxDef);
+          EM.set(b, ModelBoxDef);
           if (lastB) {
-            EM.ensureComponentOn(
-              b,
-              ScaleDef,
-              vec3.copy(vec3.create(), lastB.scale)
-            );
-            EM.ensureComponentOn(
-              b,
-              PositionDef,
-              vec3.copy(vec3.create(), lastB.position)
-            );
+            EM.set(b, ScaleDef, vec3.copy(vec3.create(), lastB.scale));
+            EM.set(b, PositionDef, vec3.copy(vec3.create(), lastB.position));
           } else {
-            EM.ensureComponentOn(b, ScaleDef, V(2, 1, 1));
-            EM.ensureComponentOn(b, PositionDef, V(0, 0, 0));
+            EM.set(b, ScaleDef, V(2, 1, 1));
+            EM.set(b, PositionDef, V(0, 0, 0));
           }
-          EM.ensureComponentOn(b, ColorDef, V(0.1, 0.3, 0.2));
-          EM.ensureComponentOn(
-            b,
-            RenderableConstructDef,
-            res.allMeshes.cube.proto
-          );
-          EM.ensureComponentOn(b, ColliderDef, {
+          EM.set(b, ColorDef, V(0.1, 0.3, 0.2));
+          EM.set(b, RenderableConstructDef, res.allMeshes.cube.proto);
+          EM.set(b, ColliderDef, {
             shape: "AABB",
             solid: false,
             aabb: res.allMeshes.cube.aabb,

--- a/src/meshes/modeler.ts
+++ b/src/meshes/modeler.ts
@@ -32,13 +32,9 @@ export const ModelerDef = EM.defineResource("modeler", () => {
   };
 });
 
-export const ModelBoxDef = EM.defineComponent(
-  "modelBox",
-  () => {
-    return true;
-  },
-  (p) => p
-);
+export const ModelBoxDef = EM.defineComponent("modelBox", () => {
+  return true;
+});
 
 function registerObjClicker() {
   // listen for modeler on/off

--- a/src/meshes/modeler.ts
+++ b/src/meshes/modeler.ts
@@ -32,7 +32,7 @@ export const ModelerDef = EM.defineResource("modeler", () => {
   };
 });
 
-export const ModelBoxDef = EM.defineComponent2(
+export const ModelBoxDef = EM.defineComponent(
   "modelBox",
   () => {
     return true;

--- a/src/meshes/modeler.ts
+++ b/src/meshes/modeler.ts
@@ -32,9 +32,13 @@ export const ModelerDef = EM.defineResource("modeler", () => {
   };
 });
 
-export const ModelBoxDef = EM.defineComponent("modelBox", () => {
-  return true;
-});
+export const ModelBoxDef = EM.defineComponent2(
+  "modelBox",
+  () => {
+    return true;
+  },
+  (p) => p
+);
 
 function registerObjClicker() {
   // listen for modeler on/off

--- a/src/motion/gravity.ts
+++ b/src/motion/gravity.ts
@@ -7,7 +7,7 @@ import { Phase } from "../ecs/sys-phase.js";
 export const GravityDef = EM.defineComponent2(
   "gravity",
   () => vec3.create(),
-  (p, gravity?: vec3) => (gravity ? vec3.copy(p, gravity) : p)
+  (p, gravity?: vec3.InputT) => (gravity ? vec3.copy(p, gravity) : p)
 );
 
 EM.addSystem(

--- a/src/motion/gravity.ts
+++ b/src/motion/gravity.ts
@@ -4,9 +4,11 @@ import { LinearVelocityDef } from "./velocity.js";
 import { TimeDef } from "../time/time.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const GravityDef = EM.defineComponent("gravity", (gravity?: vec3) => {
-  return gravity ?? vec3.create();
-});
+export const GravityDef = EM.defineComponent2(
+  "gravity",
+  () => vec3.create(),
+  (p, gravity?: vec3) => (gravity ? vec3.copy(p, gravity) : p)
+);
 
 EM.addSystem(
   "applyGravity",

--- a/src/motion/gravity.ts
+++ b/src/motion/gravity.ts
@@ -4,7 +4,7 @@ import { LinearVelocityDef } from "./velocity.js";
 import { TimeDef } from "../time/time.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const GravityDef = EM.defineComponent2(
+export const GravityDef = EM.defineComponent(
   "gravity",
   () => vec3.create(),
   (p, gravity?: vec3.InputT) => (gravity ? vec3.copy(p, gravity) : p)

--- a/src/motion/parametric-motion.ts
+++ b/src/motion/parametric-motion.ts
@@ -24,12 +24,20 @@ export const ParametricDef = EM.defineComponent(
       startMs: 0,
     };
   },
-  (p, init?: ParamProjectile, startMs?: number) => {
-    p.init = init ?? {
-      pos: V(0, 0, 0),
-      vel: V(0, 1, 0),
-      accel: V(0, 0, 0),
-    };
+  (
+    p,
+    init?: {
+      pos: vec3.InputT;
+      vel: vec3.InputT;
+      accel: vec3.InputT;
+    },
+    startMs?: number
+  ) => {
+    if (init) {
+      vec3.copy(p.init.pos, init.pos);
+      vec3.copy(p.init.vel, init.vel);
+      vec3.copy(p.init.accel, init.accel);
+    }
     p.startMs = startMs ?? 0;
     return p;
   }

--- a/src/motion/parametric-motion.ts
+++ b/src/motion/parametric-motion.ts
@@ -12,7 +12,7 @@ export interface ParamProjectile {
   accel: vec3;
 }
 
-export const ParametricDef = EM.defineComponent2(
+export const ParametricDef = EM.defineComponent(
   "parametric",
   () => {
     return {

--- a/src/motion/parametric-motion.ts
+++ b/src/motion/parametric-motion.ts
@@ -12,17 +12,26 @@ export interface ParamProjectile {
   accel: vec3;
 }
 
-export const ParametricDef = EM.defineComponent(
+export const ParametricDef = EM.defineComponent2(
   "parametric",
-  (init?: ParamProjectile, startMs?: number) => {
+  () => {
     return {
-      init: init ?? {
+      init: {
         pos: V(0, 0, 0),
         vel: V(0, 1, 0),
         accel: V(0, 0, 0),
       },
-      startMs: startMs ?? 0,
+      startMs: 0,
     };
+  },
+  (p, init?: ParamProjectile, startMs?: number) => {
+    p.init = init ?? {
+      pos: V(0, 0, 0),
+      vel: V(0, 1, 0),
+      accel: V(0, 0, 0),
+    };
+    p.startMs = startMs ?? 0;
+    return p;
   }
 );
 // TODO(@darzu): serializer pairs

--- a/src/motion/velocity.ts
+++ b/src/motion/velocity.ts
@@ -7,7 +7,7 @@ import { Phase } from "../ecs/sys-phase.js";
 export const LinearVelocityDef = EM.defineComponent2(
   "linearVelocity",
   () => V(0, 0, 0),
-  (p, v?: vec3) => (v ? vec3.copy(p, v) : p)
+  (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
 );
 export type LinearVelocity = Component<typeof LinearVelocityDef>;
 EM.registerSerializerPair(
@@ -19,7 +19,7 @@ EM.registerSerializerPair(
 export const AngularVelocityDef = EM.defineComponent2(
   "angularVelocity",
   () => V(0, 0, 0),
-  (p, v?: vec3) => (v ? vec3.copy(p, v) : p)
+  (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
 );
 export type AngularVelocity = Component<typeof AngularVelocityDef>;
 EM.registerSerializerPair(

--- a/src/motion/velocity.ts
+++ b/src/motion/velocity.ts
@@ -4,7 +4,7 @@ import { TimeDef } from "../time/time.js";
 import { PositionDef, RotationDef } from "../physics/transform.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const LinearVelocityDef = EM.defineComponent2(
+export const LinearVelocityDef = EM.defineComponent(
   "linearVelocity",
   () => V(0, 0, 0),
   (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
@@ -16,7 +16,7 @@ EM.registerSerializerPair(
   (o, buf) => buf.readVec3(o)
 );
 
-export const AngularVelocityDef = EM.defineComponent2(
+export const AngularVelocityDef = EM.defineComponent(
   "angularVelocity",
   () => V(0, 0, 0),
   (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)

--- a/src/motion/velocity.ts
+++ b/src/motion/velocity.ts
@@ -4,9 +4,10 @@ import { TimeDef } from "../time/time.js";
 import { PositionDef, RotationDef } from "../physics/transform.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const LinearVelocityDef = EM.defineComponent(
+export const LinearVelocityDef = EM.defineComponent2(
   "linearVelocity",
-  (v?: vec3) => v || V(0, 0, 0)
+  () => V(0, 0, 0),
+  (p, v?: vec3) => (v ? vec3.copy(p, v) : p)
 );
 export type LinearVelocity = Component<typeof LinearVelocityDef>;
 EM.registerSerializerPair(
@@ -15,9 +16,10 @@ EM.registerSerializerPair(
   (o, buf) => buf.readVec3(o)
 );
 
-export const AngularVelocityDef = EM.defineComponent(
+export const AngularVelocityDef = EM.defineComponent2(
   "angularVelocity",
-  (v?: vec3) => v || V(0, 0, 0)
+  () => V(0, 0, 0),
+  (p, v?: vec3) => (v ? vec3.copy(p, v) : p)
 );
 export type AngularVelocity = Component<typeof AngularVelocityDef>;
 EM.registerSerializerPair(

--- a/src/net/components.ts
+++ b/src/net/components.ts
@@ -19,31 +19,23 @@ export const SyncDef = EM.defineComponent(
 
 export type Sync = Component<typeof SyncDef>;
 
-export const PeerDef = EM.defineComponent(
-  "peer",
-  () => ({
-    address: "",
+export const PeerDef = EM.defineComponent("peer", () => ({
+  address: "",
 
-    // TODO: consider moving this state to another component
-    joined: false,
-    pid: 0,
-    updateSeq: 0,
-    entityPriorities: new Map<number, number>(),
-    entitiesKnown: new Set<number>(),
-    entitiesInUpdate: new Map<number, Set<number>>(),
-  }),
-  (p) => p
-);
+  // TODO: consider moving this state to another component
+  joined: false,
+  pid: 0,
+  updateSeq: 0,
+  entityPriorities: new Map<number, number>(),
+  entitiesKnown: new Set<number>(),
+  entitiesInUpdate: new Map<number, Set<number>>(),
+}));
 
 export type Peer = Component<typeof PeerDef>;
 
 // TODO(@darzu): BUG!! We have two versions of host, resource and component!
 export const HostDef = EM.defineResource("host", () => true);
-export const HostCompDef = EM.defineComponent(
-  "host",
-  () => true,
-  (p) => p
-);
+export const HostCompDef = EM.defineComponent("host", () => true);
 
 export const AuthorityDef = EM.defineComponent(
   "authority",
@@ -99,17 +91,12 @@ export type Me = Resource<typeof MeDef>;
 
 export const InboxDef = EM.defineComponent(
   "inbox",
-  () => new Map<MessageType, Deserializer[]>(),
-  (p) => p
+  () => new Map<MessageType, Deserializer[]>()
 );
 
 export type Inbox = Component<typeof InboxDef>;
 
-export const OutboxDef = EM.defineComponent(
-  "outbox",
-  () => [] as DataView[],
-  (p) => p
-);
+export const OutboxDef = EM.defineComponent("outbox", () => [] as DataView[]);
 
 export type Outbox = Component<typeof OutboxDef>;
 
@@ -148,19 +135,11 @@ export type Join = Component<typeof JoinDef>;
 
 // This component should be present on entities that want to participate in the
 // prediction system
-export const PredictDef = EM.defineComponent(
-  "predict",
-  () => ({
-    dt: 0,
-  }),
-  (p) => p
-);
+export const PredictDef = EM.defineComponent("predict", () => ({
+  dt: 0,
+}));
 
 export type Predict = Component<typeof PredictDef>;
 
 // Marker component for entities that have just been updated by the sync system
-export const RemoteUpdatesDef = EM.defineComponent(
-  "remoteUpdates",
-  () => true,
-  (p) => p
-);
+export const RemoteUpdatesDef = EM.defineComponent("remoteUpdates", () => true);

--- a/src/net/components.ts
+++ b/src/net/components.ts
@@ -3,7 +3,7 @@ import { Deserializer } from "../utils/serialize.js";
 import { MessageType } from "./message.js";
 import { FromNetworkEvent, ToNetworkEvent } from "./network-events.js";
 
-export const SyncDef = EM.defineComponent2(
+export const SyncDef = EM.defineComponent(
   "sync",
   () => ({
     priorityIncrementFull: 1000,
@@ -19,7 +19,7 @@ export const SyncDef = EM.defineComponent2(
 
 export type Sync = Component<typeof SyncDef>;
 
-export const PeerDef = EM.defineComponent2(
+export const PeerDef = EM.defineComponent(
   "peer",
   () => ({
     address: "",
@@ -39,13 +39,13 @@ export type Peer = Component<typeof PeerDef>;
 
 // TODO(@darzu): BUG!! We have two versions of host, resource and component!
 export const HostDef = EM.defineResource("host", () => true);
-export const HostCompDef = EM.defineComponent2(
+export const HostCompDef = EM.defineComponent(
   "host",
   () => true,
   (p) => p
 );
 
-export const AuthorityDef = EM.defineComponent2(
+export const AuthorityDef = EM.defineComponent(
   "authority",
   () => ({
     pid: 0,
@@ -97,7 +97,7 @@ export const MeDef = EM.defineResource(
 
 export type Me = Resource<typeof MeDef>;
 
-export const InboxDef = EM.defineComponent2(
+export const InboxDef = EM.defineComponent(
   "inbox",
   () => new Map<MessageType, Deserializer[]>(),
   (p) => p
@@ -105,7 +105,7 @@ export const InboxDef = EM.defineComponent2(
 
 export type Inbox = Component<typeof InboxDef>;
 
-export const OutboxDef = EM.defineComponent2(
+export const OutboxDef = EM.defineComponent(
   "outbox",
   () => [] as DataView[],
   (p) => p
@@ -148,7 +148,7 @@ export type Join = Component<typeof JoinDef>;
 
 // This component should be present on entities that want to participate in the
 // prediction system
-export const PredictDef = EM.defineComponent2(
+export const PredictDef = EM.defineComponent(
   "predict",
   () => ({
     dt: 0,
@@ -159,7 +159,7 @@ export const PredictDef = EM.defineComponent2(
 export type Predict = Component<typeof PredictDef>;
 
 // Marker component for entities that have just been updated by the sync system
-export const RemoteUpdatesDef = EM.defineComponent2(
+export const RemoteUpdatesDef = EM.defineComponent(
   "remoteUpdates",
   () => true,
   (p) => p

--- a/src/net/components.ts
+++ b/src/net/components.ts
@@ -3,38 +3,60 @@ import { Deserializer } from "../utils/serialize.js";
 import { MessageType } from "./message.js";
 import { FromNetworkEvent, ToNetworkEvent } from "./network-events.js";
 
-export const SyncDef = EM.defineComponent("sync", (dynamic?: number[]) => ({
-  priorityIncrementFull: 1000,
-  priorityIncrementDynamic: 10,
-  fullComponents: [] as number[],
-  dynamicComponents: dynamic ?? [],
-}));
+export const SyncDef = EM.defineComponent2(
+  "sync",
+  () => ({
+    priorityIncrementFull: 1000,
+    priorityIncrementDynamic: 10,
+    fullComponents: [] as number[],
+    dynamicComponents: [] as number[],
+  }),
+  (p, dynamic?: number[]) => {
+    if (dynamic) p.dynamicComponents = dynamic;
+    return p;
+  }
+);
 
 export type Sync = Component<typeof SyncDef>;
 
-export const PeerDef = EM.defineComponent("peer", () => ({
-  address: "",
+export const PeerDef = EM.defineComponent2(
+  "peer",
+  () => ({
+    address: "",
 
-  // TODO: consider moving this state to another component
-  joined: false,
-  pid: 0,
-  updateSeq: 0,
-  entityPriorities: new Map<number, number>(),
-  entitiesKnown: new Set<number>(),
-  entitiesInUpdate: new Map<number, Set<number>>(),
-}));
+    // TODO: consider moving this state to another component
+    joined: false,
+    pid: 0,
+    updateSeq: 0,
+    entityPriorities: new Map<number, number>(),
+    entitiesKnown: new Set<number>(),
+    entitiesInUpdate: new Map<number, Set<number>>(),
+  }),
+  (p) => p
+);
 
 export type Peer = Component<typeof PeerDef>;
 
 // TODO(@darzu): BUG!! We have two versions of host, resource and component!
 export const HostDef = EM.defineResource("host", () => true);
-export const HostCompDef = EM.defineComponent("host", () => true);
+export const HostCompDef = EM.defineComponent2(
+  "host",
+  () => true,
+  (p) => p
+);
 
-export const AuthorityDef = EM.defineComponent("authority", (pid?: number) => ({
-  pid: pid || 0,
-  seq: 0,
-  updateSeq: 0,
-}));
+export const AuthorityDef = EM.defineComponent2(
+  "authority",
+  () => ({
+    pid: 0,
+    seq: 0,
+    updateSeq: 0,
+  }),
+  (p, pid?: number) => {
+    if (pid) p.pid = pid;
+    return p;
+  }
+);
 
 export type Authority = Component<typeof AuthorityDef>;
 

--- a/src/net/components.ts
+++ b/src/net/components.ts
@@ -45,7 +45,7 @@ export const AuthorityDef = EM.defineComponent(
     updateSeq: 0,
   }),
   (p, pid?: number) => {
-    if (pid) p.pid = pid;
+    if (pid !== undefined) p.pid = pid;
     return p;
   }
 );

--- a/src/net/components.ts
+++ b/src/net/components.ts
@@ -97,14 +97,19 @@ export const MeDef = EM.defineResource(
 
 export type Me = Resource<typeof MeDef>;
 
-export const InboxDef = EM.defineComponent(
+export const InboxDef = EM.defineComponent2(
   "inbox",
-  () => new Map<MessageType, Deserializer[]>()
+  () => new Map<MessageType, Deserializer[]>(),
+  (p) => p
 );
 
 export type Inbox = Component<typeof InboxDef>;
 
-export const OutboxDef = EM.defineComponent("outbox", () => [] as DataView[]);
+export const OutboxDef = EM.defineComponent2(
+  "outbox",
+  () => [] as DataView[],
+  (p) => p
+);
 
 export type Outbox = Component<typeof OutboxDef>;
 
@@ -143,11 +148,19 @@ export type Join = Component<typeof JoinDef>;
 
 // This component should be present on entities that want to participate in the
 // prediction system
-export const PredictDef = EM.defineComponent("predict", () => ({
-  dt: 0,
-}));
+export const PredictDef = EM.defineComponent2(
+  "predict",
+  () => ({
+    dt: 0,
+  }),
+  (p) => p
+);
 
 export type Predict = Component<typeof PredictDef>;
 
 // Marker component for entities that have just been updated by the sync system
-export const RemoteUpdatesDef = EM.defineComponent("remoteUpdates", () => true);
+export const RemoteUpdatesDef = EM.defineComponent2(
+  "remoteUpdates",
+  () => true,
+  (p) => p
+);

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -183,7 +183,13 @@ function runEvent<Extra>(type: string, event: Event<Extra>) {
   const entities = event.entities.map((id, idx) => {
     const entity = EM.findEntity(id, [])!;
     for (const cdef of handler.entities[idx] as ComponentDef[]) {
-      EM.set(entity, cdef);
+      // TODO(@darzu): I'm a little nervous about this. We should only be calling
+      // the constructor(), not the update(), and we need to assert that all the components
+      // are updatable?
+      if (!cdef.isOn(entity)) {
+        // console.log(`runEvent setting ${cdef.name} on ${entity.id}`);
+        EM.setOnce(entity, cdef);
+      }
     }
     return entity;
   });

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -221,13 +221,17 @@ export type DetectedEvents = Component<typeof DetectedEventsDef>;
 
 // Outgoing event requests queue. Should be attached to the host
 // peer, shouldn't exist at the host itself
-export const OutgoingEventRequestsDef = EM.defineComponent(
+export const OutgoingEventRequestsDef = EM.defineComponent2(
   "outgoingEventRequests",
-  (nextId?: number) => ({
+  () => ({
     lastSendTime: 0,
-    nextId: nextId || 0,
+    nextId: 0,
     events: [] as { id: number; event: DetectedEvent<any> }[],
-  })
+  }),
+  (p, nextId?: number) => {
+    if (nextId) p.nextId = nextId;
+    return p;
+  }
 );
 
 // Exists only at the host. This is a list of all events requested
@@ -239,13 +243,17 @@ const RequestedEventsDef = EM.defineResource(
 
 // TODO: find a better name for this
 // Attached to each peer by the event system at the host
-const EventSyncDef = EM.defineComponent("eventSync", () => ({
-  // The next unacked event ID from this peer
-  nextId: 0,
-  // The next event sequence number this peer should see
-  nextSeq: 0,
-  lastSendTime: 0,
-}));
+const EventSyncDef = EM.defineComponent2(
+  "eventSync",
+  () => ({
+    // The next unacked event ID from this peer
+    nextId: 0,
+    // The next event sequence number this peer should see
+    nextSeq: 0,
+    lastSendTime: 0,
+  }),
+  (p) => p
+);
 
 const EventsDef = EM.defineResource("events", () => ({
   log: [] as Event<any>[],

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -221,17 +221,13 @@ export type DetectedEvents = Component<typeof DetectedEventsDef>;
 
 // Outgoing event requests queue. Should be attached to the host
 // peer, shouldn't exist at the host itself
-export const OutgoingEventRequestsDef = EM.defineComponent(
+export const OutgoingEventRequestsDef = EM.defineNonupdatableComponent(
   "outgoingEventRequests",
-  () => ({
+  (nextId?: number) => ({
     lastSendTime: 0,
-    nextId: 0,
+    nextId: nextId || 0,
     events: [] as { id: number; event: DetectedEvent<any> }[],
-  }),
-  (p, nextId?: number) => {
-    if (nextId) p.nextId = nextId;
-    return p;
-  }
+  })
 );
 
 // Exists only at the host. This is a list of all events requested
@@ -243,17 +239,13 @@ const RequestedEventsDef = EM.defineResource(
 
 // TODO: find a better name for this
 // Attached to each peer by the event system at the host
-const EventSyncDef = EM.defineComponent(
-  "eventSync",
-  () => ({
-    // The next unacked event ID from this peer
-    nextId: 0,
-    // The next event sequence number this peer should see
-    nextSeq: 0,
-    lastSendTime: 0,
-  }),
-  (p) => p
-);
+const EventSyncDef = EM.defineComponent("eventSync", () => ({
+  // The next unacked event ID from this peer
+  nextId: 0,
+  // The next event sequence number this peer should see
+  nextSeq: 0,
+  lastSendTime: 0,
+}));
 
 const EventsDef = EM.defineResource("events", () => ({
   log: [] as Event<any>[],

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -285,7 +285,7 @@ export function initNetGameEventSystems() {
     (hosts, { detectedEvents, me, time }) => {
       if (hosts.length == 0) return;
       const host = hosts[0];
-      EM.set(host, OutgoingEventRequestsDef);
+      EM.setOnce(host, OutgoingEventRequestsDef);
       let newEvents = false;
       while (detectedEvents.events.length > 0) {
         const event = detectedEvents.events.shift()!;

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -183,7 +183,7 @@ function runEvent<Extra>(type: string, event: Event<Extra>) {
   const entities = event.entities.map((id, idx) => {
     const entity = EM.findEntity(id, [])!;
     for (const cdef of handler.entities[idx] as ComponentDef[]) {
-      EM.ensureComponentOn(entity, cdef);
+      EM.set(entity, cdef);
     }
     return entity;
   });
@@ -285,10 +285,7 @@ export function initNetGameEventSystems() {
     (hosts, { detectedEvents, me, time }) => {
       if (hosts.length == 0) return;
       const host = hosts[0];
-      const outgoingEventRequests = EM.ensureComponent(
-        host.id,
-        OutgoingEventRequestsDef
-      );
+      EM.set(host, OutgoingEventRequestsDef);
       let newEvents = false;
       while (detectedEvents.events.length > 0) {
         const event = detectedEvents.events.shift()!;
@@ -299,28 +296,29 @@ export function initNetGameEventSystems() {
           if (!legalEvent(event.type, event))
             throw `illegal event ${event.type}`;
           newEvents = true;
-          outgoingEventRequests.events.push({
-            id: outgoingEventRequests.nextId++,
+          host.outgoingEventRequests.events.push({
+            id: host.outgoingEventRequests.nextId++,
             event,
           });
         }
       }
       // We should send a message if we have new events to send or it's time to retransmit old events
       if (
-        outgoingEventRequests.events.length > 0 &&
+        host.outgoingEventRequests.events.length > 0 &&
         (newEvents ||
-          outgoingEventRequests.lastSendTime + EVENT_RETRANSMIT_MS < time.time)
+          host.outgoingEventRequests.lastSendTime + EVENT_RETRANSMIT_MS <
+            time.time)
       ) {
         console.log(
-          `Sending ${outgoingEventRequests.events.length} event requests (newEvents=${newEvents}, lastSendTime=${outgoingEventRequests.lastSendTime}, time=${time.time}`
+          `Sending ${host.outgoingEventRequests.events.length} event requests (newEvents=${newEvents}, lastSendTime=${host.outgoingEventRequests.lastSendTime}, time=${time.time}`
         );
         let message = new Serializer(MAX_MESSAGE_SIZE);
         message.writeUint8(MessageType.EventRequests);
-        message.writeUint32(outgoingEventRequests.events[0].id);
+        message.writeUint32(host.outgoingEventRequests.events[0].id);
         let numEvents = 0;
         let numEventsIndex = message.writeUint8(numEvents);
         try {
-          for (let { event } of outgoingEventRequests.events) {
+          for (let { event } of host.outgoingEventRequests.events) {
             serializeDetectedEvent(event, message);
             numEvents++;
           }
@@ -329,7 +327,7 @@ export function initNetGameEventSystems() {
         }
         message.writeUint8(numEvents, numEventsIndex);
         send(host.outbox, message.buffer);
-        outgoingEventRequests.lastSendTime = time.time;
+        host.outgoingEventRequests.lastSendTime = time.time;
       }
     }
   );

--- a/src/net/events.ts
+++ b/src/net/events.ts
@@ -221,7 +221,7 @@ export type DetectedEvents = Component<typeof DetectedEventsDef>;
 
 // Outgoing event requests queue. Should be attached to the host
 // peer, shouldn't exist at the host itself
-export const OutgoingEventRequestsDef = EM.defineComponent2(
+export const OutgoingEventRequestsDef = EM.defineComponent(
   "outgoingEventRequests",
   () => ({
     lastSendTime: 0,
@@ -243,7 +243,7 @@ const RequestedEventsDef = EM.defineResource(
 
 // TODO: find a better name for this
 // Attached to each peer by the event system at the host
-const EventSyncDef = EM.defineComponent2(
+const EventSyncDef = EM.defineComponent(
   "eventSync",
   () => ({
     // The next unacked event ID from this peer

--- a/src/net/game-multiplayer.ts
+++ b/src/net/game-multiplayer.ts
@@ -112,9 +112,9 @@ export const {
     const props = e.mpPlayerProps;
 
     // TODO(@darzu): BUG. props.color is undefined
-    EM.ensureComponentOn(e, ColorDef, props.color);
-    EM.ensureComponentOn(e, RenderableConstructDef, res.mesh_cube.proto);
-    EM.ensureComponentOn(e, ColliderDef, {
+    EM.set(e, ColorDef, props.color);
+    EM.set(e, RenderableConstructDef, res.mesh_cube.proto);
+    EM.set(e, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: res.mesh_cube.aabb,
@@ -123,11 +123,11 @@ export const {
     if (e.authority.pid === res.me.pid) {
       vec3.copy(e.position, props.location); // TODO(@darzu): should be fine to have this outside loop
 
-      EM.ensureComponentOn(e, ControllableDef);
+      EM.set(e, ControllableDef);
       e.controllable.modes.canFall = true;
       e.controllable.modes.canJump = false;
       e.controllable.modes.canFly = false;
-      EM.ensureComponentOn(e, CameraFollowDef, 1);
+      EM.set(e, CameraFollowDef, 1);
       quat.setAxisAngle([0.0, -1.0, 0.0], 1.62, e.rotation);
       e.controllable.speed *= 2;
       e.controllable.sprintMul = 1;
@@ -173,32 +173,27 @@ export async function initMPGame() {
 
   // light
   const sun = EM.new();
-  EM.ensureComponentOn(sun, PointLightDef);
-  EM.ensureComponentOn(sun, ColorDef, V(1, 1, 1));
+  EM.set(sun, PointLightDef);
+  EM.set(sun, ColorDef, V(1, 1, 1));
   // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
   // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
-  EM.ensureComponentOn(sun, PositionDef, V(100, 100, 100));
-  EM.ensureComponentOn(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
-  EM.ensureComponentOn(
-    sun,
-    RenderableConstructDef,
-    mp_meshes.ball.proto,
-    false
-  );
+  EM.set(sun, PositionDef, V(100, 100, 100));
+  EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
+  EM.set(sun, RenderableConstructDef, mp_meshes.ball.proto, false);
   sun.pointLight.constant = 1.0;
   sun.pointLight.linear = 0.0;
   sun.pointLight.quadratic = 0.0;
   vec3.copy(sun.pointLight.ambient, [0.2, 0.2, 0.2]);
   vec3.copy(sun.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sun, PositionDef, V(50, 300, 10));
+  EM.set(sun, PositionDef, V(50, 300, 10));
 
   // ground
   const ground = EM.new();
-  EM.ensureComponentOn(ground, RenderableConstructDef, mp_meshes.hex.proto);
-  EM.ensureComponentOn(ground, ColorDef, ENDESGA16.blue);
-  EM.ensureComponentOn(ground, PositionDef, V(0, -10, 0));
-  EM.ensureComponentOn(ground, ScaleDef, V(10, 10, 10));
-  EM.ensureComponentOn(ground, ColliderDef, {
+  EM.set(ground, RenderableConstructDef, mp_meshes.hex.proto);
+  EM.set(ground, ColorDef, ENDESGA16.blue);
+  EM.set(ground, PositionDef, V(0, -10, 0));
+  EM.set(ground, ScaleDef, V(10, 10, 10));
+  EM.set(ground, ColliderDef, {
     shape: "AABB",
     solid: true,
     aabb: mp_meshes.hex.aabb,
@@ -207,8 +202,8 @@ export async function initMPGame() {
   // gizmo
   const gizmoMesh = createGizmoMesh();
   const gizmo = EM.new();
-  EM.ensureComponentOn(gizmo, RenderableConstructDef, gizmoMesh);
-  EM.ensureComponentOn(gizmo, PositionDef, V(0, 1, 0));
+  EM.set(gizmo, RenderableConstructDef, gizmoMesh);
+  EM.set(gizmo, PositionDef, V(0, 1, 0));
 
   // player
   const color = AllEndesga16[me.pid];

--- a/src/net/game-multiplayer.ts
+++ b/src/net/game-multiplayer.ts
@@ -63,7 +63,7 @@ export const {
       color: V(0, 0, 0),
     };
   },
-  updateProps: (p, location?: vec3, color?: vec3) => {
+  updateProps: (p, location?: vec3.InputT, color?: vec3.InputT) => {
     console.log(
       `updating mpPlayerProps w/ ${vec3Dbg(location)} ${vec3Dbg(color)}`
     );
@@ -71,32 +71,18 @@ export const {
     if (color) vec3.copy(p.color, color);
     return p;
   },
-  // TODO(@darzu): can't do this b/c constructors must create a valid shape even when given no params
-  // defaultProps: (location: vec3, color: vec3) => {
-  //   console.log(
-  //     `creating mpPlayerProps w/ ${vec3Dbg(location)} ${vec3Dbg(color)}`
-  //   );
-  //   return {
-  //     location: location,
-  //     color: color,
-  //   };
-  // },
   serializeProps: (c, buf) => {
     buf.writeVec3(c.location);
     buf.writeVec3(c.color);
     console.log(
-      `serialized mpPlayerProps w/ ${
-        c.location ? vec3Dbg(c.location) : "NULL"
-      } ${c.color ? vec3Dbg(c.color) : "NULL"}`
+      `serialized mpPlayerProps w/ ${vec3Dbg(c.location)} ${vec3Dbg(c.color)}`
     );
   },
   deserializeProps: (c, buf) => {
     buf.readVec3(c.location);
     buf.readVec3(c.color);
     console.log(
-      `deserialized mpPlayerProps w/ ${
-        c.location ? vec3Dbg(c.location) : "NULL"
-      } ${c.color ? vec3Dbg(c.color) : "NULL"}`
+      `deserialized mpPlayerProps w/ ${vec3Dbg(c.location)} ${vec3Dbg(c.color)}`
     );
   },
   defaultLocal: () => {

--- a/src/net/game-multiplayer.ts
+++ b/src/net/game-multiplayer.ts
@@ -57,14 +57,19 @@ export const {
   createMpPlayerNow,
 } = defineNetEntityHelper({
   name: "mpPlayer",
-  defaultProps: (location?: vec3, color?: vec3) => {
-    console.log(
-      `creating mpPlayerProps w/ ${vec3Dbg(location)} ${vec3Dbg(color)}`
-    );
+  defaultProps: () => {
     return {
-      location: location ?? V(0, 0, 0),
-      color: color ?? V(0, 0, 0),
+      location: V(0, 0, 0),
+      color: V(0, 0, 0),
     };
+  },
+  updateProps: (p, location?: vec3, color?: vec3) => {
+    console.log(
+      `updating mpPlayerProps w/ ${vec3Dbg(location)} ${vec3Dbg(color)}`
+    );
+    if (location) vec3.copy(p.location, location);
+    if (color) vec3.copy(p.color, color);
+    return p;
   },
   // TODO(@darzu): can't do this b/c constructors must create a valid shape even when given no params
   // defaultProps: (location: vec3, color: vec3) => {

--- a/src/net/game-multiplayer.ts
+++ b/src/net/game-multiplayer.ts
@@ -175,8 +175,8 @@ export async function initMPGame() {
   const sun = EM.new();
   EM.set(sun, PointLightDef);
   EM.set(sun, ColorDef, V(1, 1, 1));
-  // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
-  // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
+  // EM.set(sun, PositionDef, V(100, 100, 0));
+  // EM.set(sun, PositionDef, V(-10, 10, 10));
   EM.set(sun, PositionDef, V(100, 100, 100));
   EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
   EM.set(sun, RenderableConstructDef, mp_meshes.ball.proto, false);

--- a/src/net/join.ts
+++ b/src/net/join.ts
@@ -47,7 +47,7 @@ function registerConnectToServer() {
           const peers = EM.filterEntities([PeerDef]);
           // TODO: this is a hacky way to tell if we're connected.
           if (peers.length > 0) {
-            EM.addComponent(peers[0].id, HostCompDef);
+            EM.set(peers[0], HostCompDef);
             // TODO: consider putting this message into the outbox rather than directly on the event queue
             let message = new Serializer(8);
             message.writeUint8(MessageType.Join);

--- a/src/net/net-debug.ts
+++ b/src/net/net-debug.ts
@@ -39,7 +39,7 @@ export function initNetDebugSystem() {
     (objs, res) => {
       for (const o of objs) {
         if (res.netDebugState.dbgAuthority) {
-          EM.ensureComponentOn(o, TintsDef);
+          EM.set(o, TintsDef);
           setTint(
             o.tints,
             AUTHORITY_TINT_NAME,

--- a/src/ocean/ocean.ts
+++ b/src/ocean/ocean.ts
@@ -128,7 +128,7 @@ export async function initOcean(oceanMesh: Mesh, color: vec3) {
     // meshPoolPtr
   );
   EM.set(ocean, ColorDef, color);
-  //EM.ensureComponentOn(ocean, PositionDef, [12000, 180, 0]);
+  //EM.set(ocean, PositionDef, [12000, 180, 0]);
   EM.set(ocean, PositionDef);
 
   let ocean2 = await EM.whenEntityHas(ocean, RenderableDef, RenderDataOceanDef);

--- a/src/ocean/ocean.ts
+++ b/src/ocean/ocean.ts
@@ -77,9 +77,10 @@ export const OceanDef = EM.defineResource("ocean", (o: UVSurface) => {
   return o;
 });
 
-export const UVPosDef = EM.defineComponent(
+export const UVPosDef = EM.defineComponent2(
   "uvPos",
-  (uv?: vec2) => uv ?? vec2.create()
+  () => vec2.create(),
+  (p, uv?: vec2.InputT) => (uv ? vec2.copy(p, uv) : p)
 );
 EM.registerSerializerPair(
   UVPosDef,
@@ -87,9 +88,10 @@ EM.registerSerializerPair(
   (o, buf) => buf.readVec2(o)
 );
 
-export const UVDirDef = EM.defineComponent(
+export const UVDirDef = EM.defineComponent2(
   "uvDir",
-  (dir?: vec2) => dir ?? vec2.fromValues(0, 1)
+  () => V(0, 1),
+  (p, dir?: vec2.InputT) => (dir ? vec2.copy(p, dir) : p)
 );
 EM.registerSerializerPair(
   UVDirDef,

--- a/src/ocean/ocean.ts
+++ b/src/ocean/ocean.ts
@@ -115,7 +115,7 @@ export async function initOcean(oceanMesh: Mesh, color: vec3) {
 
   const ocean = EM.new();
   let oceanEntId = ocean.id; // hacky?
-  EM.ensureComponentOn(
+  EM.set(
     ocean,
     RenderableConstructDef,
     // TODO(@darzu): SEPERATE THIS DEPENDENCY! Need ocean w/o mesh
@@ -127,9 +127,9 @@ export async function initOcean(oceanMesh: Mesh, color: vec3) {
     oceanPoolPtr
     // meshPoolPtr
   );
-  EM.ensureComponentOn(ocean, ColorDef, color);
+  EM.set(ocean, ColorDef, color);
   //EM.ensureComponentOn(ocean, PositionDef, [12000, 180, 0]);
-  EM.ensureComponentOn(ocean, PositionDef);
+  EM.set(ocean, PositionDef);
 
   let ocean2 = await EM.whenEntityHas(ocean, RenderableDef, RenderDataOceanDef);
   // let ocean2 = await EM.whenEntityHas(ocean, RenderableDef, RenderDataStdDef);

--- a/src/ocean/ocean.ts
+++ b/src/ocean/ocean.ts
@@ -77,7 +77,7 @@ export const OceanDef = EM.defineResource("ocean", (o: UVSurface) => {
   return o;
 });
 
-export const UVPosDef = EM.defineComponent2(
+export const UVPosDef = EM.defineComponent(
   "uvPos",
   () => vec2.create(),
   (p, uv?: vec2.InputT) => (uv ? vec2.copy(p, uv) : p)
@@ -88,7 +88,7 @@ EM.registerSerializerPair(
   (o, buf) => buf.readVec2(o)
 );
 
-export const UVDirDef = EM.defineComponent2(
+export const UVDirDef = EM.defineComponent(
   "uvDir",
   () => V(0, 1),
   (p, dir?: vec2.InputT) => (dir ? vec2.copy(p, dir) : p)

--- a/src/physics/collider.ts
+++ b/src/physics/collider.ts
@@ -69,27 +69,19 @@ export type Collider =
   | CapsuleCollider
   | MultiCollider;
 
-const NonCollider: EmptyCollider = {
-  shape: "Empty",
-  solid: false,
-};
-
 // TODO(@darzu): ensure we support swapping colliders?
-export const ColliderDef = EM.defineComponent(
+export const ColliderDef = EM.defineNonupdatableComponent(
   "collider",
-  () => {
-    return {
-      shape: "Empty",
-      solid: false,
-    } as Collider;
-  },
-  (p, c?: Collider) => {
-    // TODO(@darzu): PERF. In most cases this is creating an empty collider and immediately throwing that away
-    if (c) return c;
-    return p;
+  (c?: Collider) => {
+    return (
+      c ??
+      ({
+        shape: "Empty",
+        solid: false,
+      } as Collider)
+    );
   }
 );
-
 const __COLLIDER_ASSERT: Component<typeof ColliderDef> extends Collider
   ? true
   : false = true;

--- a/src/physics/collider.ts
+++ b/src/physics/collider.ts
@@ -69,16 +69,27 @@ export type Collider =
   | CapsuleCollider
   | MultiCollider;
 
+const NonCollider: EmptyCollider = {
+  shape: "Empty",
+  solid: false,
+};
+
 // TODO(@darzu): ensure we support swapping colliders?
-export const ColliderDef = EM.defineComponent("collider", (c?: Collider) => {
-  return (
-    c ??
-    ({
+export const ColliderDef = EM.defineComponent2(
+  "collider",
+  () => {
+    return {
       shape: "Empty",
       solid: false,
-    } as Collider)
-  );
-});
+    } as Collider;
+  },
+  (p, c?: Collider) => {
+    // TODO(@darzu): PERF. In most cases this is creating an empty collider and immediately throwing that away
+    if (c) return c;
+    return p;
+  }
+);
+
 const __COLLIDER_ASSERT: Component<typeof ColliderDef> extends Collider
   ? true
   : false = true;

--- a/src/physics/collider.ts
+++ b/src/physics/collider.ts
@@ -75,7 +75,7 @@ const NonCollider: EmptyCollider = {
 };
 
 // TODO(@darzu): ensure we support swapping colliders?
-export const ColliderDef = EM.defineComponent2(
+export const ColliderDef = EM.defineComponent(
   "collider",
   () => {
     return {

--- a/src/physics/game-gjk.ts
+++ b/src/physics/game-gjk.ts
@@ -89,7 +89,7 @@ export async function initGJKSandbox(hosting: boolean) {
 
   // ghost
   const g = createGhost();
-  // EM.ensureComponentOn(g, RenderableConstructDef, res.allMeshes.cube.proto);
+  // EM.set(g, RenderableConstructDef, res.allMeshes.cube.proto);
   // createPlayer();
 
   // vec3.copy(e.position, [-16.6, 5, -5.1]);
@@ -142,7 +142,7 @@ export async function initGJKSandbox(hosting: boolean) {
     solid: false,
     aabb: res.allMeshes.cube.aabb,
   });
-  // EM.ensureComponentOn(b1, ColliderDef, {
+  // EM.set(b1, ColliderDef, {
   //   shape: "Box",
   //   solid: false,
   //   center: res.allMeshes.cube.center,
@@ -154,15 +154,15 @@ export async function initGJKSandbox(hosting: boolean) {
   EM.set(b2, RenderableConstructDef, m2);
   EM.set(b2, ColorDef, V(0.1, 0.1, 0.1));
   EM.set(b2, PositionDef, V(0, 0, 0));
-  // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+  // EM.set(b2, PositionDef, [0, 0, -1.2]);
   EM.set(b2, WorldFrameDef);
-  // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+  // EM.set(b2, PhysicsParentDef, g.id);
   EM.set(b2, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.cube.aabb,
   });
-  // EM.ensureComponentOn(b2, ColliderDef, {
+  // EM.set(b2, ColliderDef, {
   //   shape: "Box",
   //   solid: false,
   //   center: res.allMeshes.cube.center,

--- a/src/physics/game-gjk.ts
+++ b/src/physics/game-gjk.ts
@@ -79,17 +79,13 @@ export async function initGJKSandbox(hosting: boolean) {
 
   // sun
   const sunlight = EM.new();
-  EM.ensureComponentOn(sunlight, PointLightDef);
+  EM.set(sunlight, PointLightDef);
   sunlight.pointLight.constant = 1.0;
   vec3.copy(sunlight.pointLight.ambient, [0.8, 0.8, 0.8]);
   // vec3.scale(sunlight.pointLight.ambient, sunlight.pointLight.ambient, 0.2);
   // vec3.copy(sunlight.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sunlight, PositionDef, V(10, 100, 10));
-  EM.ensureComponentOn(
-    sunlight,
-    RenderableConstructDef,
-    res.allMeshes.ball.proto
-  );
+  EM.set(sunlight, PositionDef, V(10, 100, 10));
+  EM.set(sunlight, RenderableConstructDef, res.allMeshes.ball.proto);
 
   // ghost
   const g = createGhost();
@@ -122,30 +118,26 @@ export async function initGJKSandbox(hosting: boolean) {
 
   // ground
   const ground = EM.new();
-  EM.ensureComponentOn(
-    ground,
-    RenderableConstructDef,
-    res.allMeshes.plane.proto
-  );
-  EM.ensureComponentOn(ground, ColorDef, V(0.2, 0.3, 0.2));
-  EM.ensureComponentOn(ground, PositionDef, V(0, -5, 0));
+  EM.set(ground, RenderableConstructDef, res.allMeshes.plane.proto);
+  EM.set(ground, ColorDef, V(0.2, 0.3, 0.2));
+  EM.set(ground, PositionDef, V(0, -5, 0));
 
   // world gizmo
   const gizmoMesh = await GizmoMesh.gameMesh();
   const worldGizmo = EM.new();
-  EM.ensureComponentOn(worldGizmo, PositionDef, V(-10, -5, -10));
-  EM.ensureComponentOn(worldGizmo, ScaleDef, V(10, 10, 10));
-  EM.ensureComponentOn(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
+  EM.set(worldGizmo, PositionDef, V(-10, -5, -10));
+  EM.set(worldGizmo, ScaleDef, V(10, 10, 10));
+  EM.set(worldGizmo, RenderableConstructDef, gizmoMesh.proto);
 
   const b1 = EM.new();
   const m1 = cloneMesh(res.allMeshes.cube.mesh);
-  EM.ensureComponentOn(b1, RenderableConstructDef, m1);
-  EM.ensureComponentOn(b1, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(b1, PositionDef, V(0, 0, 3));
-  EM.ensureComponentOn(b1, RotationDef);
-  EM.ensureComponentOn(b1, AngularVelocityDef, V(0, 0.001, 0.001));
-  EM.ensureComponentOn(b1, WorldFrameDef);
-  EM.ensureComponentOn(b1, ColliderDef, {
+  EM.set(b1, RenderableConstructDef, m1);
+  EM.set(b1, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(b1, PositionDef, V(0, 0, 3));
+  EM.set(b1, RotationDef);
+  EM.set(b1, AngularVelocityDef, V(0, 0.001, 0.001));
+  EM.set(b1, WorldFrameDef);
+  EM.set(b1, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.cube.aabb,
@@ -159,13 +151,13 @@ export async function initGJKSandbox(hosting: boolean) {
 
   const b2 = g;
   const m2 = cloneMesh(res.allMeshes.cube.mesh);
-  EM.ensureComponentOn(b2, RenderableConstructDef, m2);
-  EM.ensureComponentOn(b2, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(b2, PositionDef, V(0, 0, 0));
+  EM.set(b2, RenderableConstructDef, m2);
+  EM.set(b2, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(b2, PositionDef, V(0, 0, 0));
   // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-  EM.ensureComponentOn(b2, WorldFrameDef);
+  EM.set(b2, WorldFrameDef);
   // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-  EM.ensureComponentOn(b2, ColliderDef, {
+  EM.set(b2, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.cube.aabb,
@@ -179,12 +171,12 @@ export async function initGJKSandbox(hosting: boolean) {
 
   const b3 = EM.new();
   const m3 = cloneMesh(res.allMeshes.ball.mesh);
-  EM.ensureComponentOn(b3, RenderableConstructDef, m3);
-  EM.ensureComponentOn(b3, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(b3, PositionDef, V(0, 0, -4));
-  EM.ensureComponentOn(b3, RotationDef);
-  EM.ensureComponentOn(b3, WorldFrameDef);
-  EM.ensureComponentOn(b3, ColliderDef, {
+  EM.set(b3, RenderableConstructDef, m3);
+  EM.set(b3, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(b3, PositionDef, V(0, 0, -4));
+  EM.set(b3, RotationDef);
+  EM.set(b3, WorldFrameDef);
+  EM.set(b3, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.ball.aabb,
@@ -192,12 +184,12 @@ export async function initGJKSandbox(hosting: boolean) {
 
   const b4 = EM.new();
   const m4 = cloneMesh(res.allMeshes.tetra.mesh);
-  EM.ensureComponentOn(b4, RenderableConstructDef, m4);
-  EM.ensureComponentOn(b4, ColorDef, V(0.1, 0.1, 0.1));
-  EM.ensureComponentOn(b4, PositionDef, V(0, -3, 0));
-  EM.ensureComponentOn(b4, RotationDef);
-  EM.ensureComponentOn(b4, WorldFrameDef);
-  EM.ensureComponentOn(b4, ColliderDef, {
+  EM.set(b4, RenderableConstructDef, m4);
+  EM.set(b4, ColorDef, V(0.1, 0.1, 0.1));
+  EM.set(b4, PositionDef, V(0, -3, 0));
+  EM.set(b4, RotationDef);
+  EM.set(b4, WorldFrameDef);
+  EM.set(b4, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.tetra.aabb,

--- a/src/physics/game-rebound.ts
+++ b/src/physics/game-rebound.ts
@@ -92,11 +92,7 @@ export async function initReboundSandbox(hosting: boolean) {
 
   res.text.lowerText = `spawner (p) stack (l) clear (backspace)`;
 
-  const cubeDef = EM.defineComponent(
-    "cube",
-    () => true,
-    (p) => p
-  );
+  const cubeDef = EM.defineComponent("cube", () => true);
 
   function spawn(m: GameMesh, pos: vec3) {
     const e = EM.new();

--- a/src/physics/game-rebound.ts
+++ b/src/physics/game-rebound.ts
@@ -65,25 +65,21 @@ export async function initReboundSandbox(hosting: boolean) {
   c.renderable.enabled = false;
 
   const p = EM.new();
-  EM.ensureComponentOn(p, RenderableConstructDef, res.allMeshes.plane.proto);
-  EM.ensureComponentOn(p, ColorDef, V(0.2, 0.3, 0.2));
-  EM.ensureComponentOn(p, PositionDef, V(0, -10, 0));
-  EM.ensureComponentOn(p, ColliderDef, {
+  EM.set(p, RenderableConstructDef, res.allMeshes.plane.proto);
+  EM.set(p, ColorDef, V(0.2, 0.3, 0.2));
+  EM.set(p, PositionDef, V(0, -10, 0));
+  EM.set(p, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: res.allMeshes.plane.aabb,
   });
 
   const t = EM.new();
-  EM.ensureComponentOn(
-    t,
-    RenderableConstructDef,
-    res.allMeshes.gridPlane.proto
-  );
-  EM.ensureComponentOn(t, ColorDef, V(0.2, 0.2, 0.9));
-  EM.ensureComponentOn(t, PositionDef, V(0, 0, 0));
-  EM.ensureComponentOn(t, AngularVelocityDef, V(0, 0.0002, 0.0002));
-  EM.ensureComponentOn(t, ColliderDef, {
+  EM.set(t, RenderableConstructDef, res.allMeshes.gridPlane.proto);
+  EM.set(t, ColorDef, V(0.2, 0.2, 0.9));
+  EM.set(t, PositionDef, V(0, 0, 0));
+  EM.set(t, AngularVelocityDef, V(0, 0.0002, 0.0002));
+  EM.set(t, ColliderDef, {
     shape: "AABB",
     solid: true,
     aabb: res.allMeshes.gridPlane.aabb,
@@ -96,21 +92,21 @@ export async function initReboundSandbox(hosting: boolean) {
 
   function spawn(m: GameMesh, pos: vec3) {
     const e = EM.new();
-    EM.ensureComponentOn(e, RenderableConstructDef, m.proto);
+    EM.set(e, RenderableConstructDef, m.proto);
     const [r, g, b] = [jitter(0.1) + 0.2, jitter(0.1) + 0.2, jitter(0.1) + 0.2];
-    EM.ensureComponentOn(e, ColorDef, V(r, g, b));
-    EM.ensureComponentOn(e, PositionDef, pos);
-    EM.ensureComponentOn(e, ScaleDef, V(0.5, 0.5, 0.5));
+    EM.set(e, ColorDef, V(r, g, b));
+    EM.set(e, PositionDef, pos);
+    EM.set(e, ScaleDef, V(0.5, 0.5, 0.5));
     // EM.ensureComponentOn(b, RotationDef);
     // EM.ensureComponentOn(b, AngularVelocityDef, [0, 0.001, 0.001]);
-    EM.ensureComponentOn(e, LinearVelocityDef, V(0, -0.02, 0));
-    EM.ensureComponentOn(e, PhysicsParentDef, tableId);
-    EM.ensureComponentOn(e, ColliderDef, {
+    EM.set(e, LinearVelocityDef, V(0, -0.02, 0));
+    EM.set(e, PhysicsParentDef, tableId);
+    EM.set(e, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: m.aabb,
     });
-    EM.ensureComponentOn(e, cubeDef);
+    EM.set(e, cubeDef);
   }
 
   let nextSpawnAccu = 0;
@@ -146,7 +142,7 @@ export async function initReboundSandbox(hosting: boolean) {
 
       if (res.inputs.keyClicks["backspace"]) {
         const es = EM.filterEntities([cubeDef]);
-        for (let e of es) EM.ensureComponentOn(e, DeletedDef);
+        for (let e of es) EM.set(e, DeletedDef);
       }
     }
   );

--- a/src/physics/game-rebound.ts
+++ b/src/physics/game-rebound.ts
@@ -97,8 +97,8 @@ export async function initReboundSandbox(hosting: boolean) {
     EM.set(e, ColorDef, V(r, g, b));
     EM.set(e, PositionDef, pos);
     EM.set(e, ScaleDef, V(0.5, 0.5, 0.5));
-    // EM.ensureComponentOn(b, RotationDef);
-    // EM.ensureComponentOn(b, AngularVelocityDef, [0, 0.001, 0.001]);
+    // EM.set(b, RotationDef);
+    // EM.set(b, AngularVelocityDef, [0, 0.001, 0.001]);
     EM.set(e, LinearVelocityDef, V(0, -0.02, 0));
     EM.set(e, PhysicsParentDef, tableId);
     EM.set(e, ColliderDef, {

--- a/src/physics/game-rebound.ts
+++ b/src/physics/game-rebound.ts
@@ -92,7 +92,11 @@ export async function initReboundSandbox(hosting: boolean) {
 
   res.text.lowerText = `spawner (p) stack (l) clear (backspace)`;
 
-  const cubeDef = EM.defineComponent("cube", () => true);
+  const cubeDef = EM.defineComponent2(
+    "cube",
+    () => true,
+    (p) => p
+  );
 
   function spawn(m: GameMesh, pos: vec3) {
     const e = EM.new();

--- a/src/physics/game-rebound.ts
+++ b/src/physics/game-rebound.ts
@@ -92,7 +92,7 @@ export async function initReboundSandbox(hosting: boolean) {
 
   res.text.lowerText = `spawner (p) stack (l) clear (backspace)`;
 
-  const cubeDef = EM.defineComponent2(
+  const cubeDef = EM.defineComponent(
     "cube",
     () => true,
     (p) => p

--- a/src/physics/nonintersection.ts
+++ b/src/physics/nonintersection.ts
@@ -92,16 +92,20 @@ const DUMMY_COLLIDER: PhysCollider = {
 };
 
 // TODO(@darzu): break this up into the specific use cases
-export const PhysicsStateDef = EM.defineComponent("_phys", () => {
-  return {
-    // track last stats so we can diff
-    lastLocalPos: PositionDef.construct(),
-    // Colliders
-    // NOTE: these can be many-to-one colliders-to-entities, hence the arrays
-    colliders: [] as PhysCollider[],
-    // TODO(@darzu): use sweepAABBs again?
-  };
-});
+export const PhysicsStateDef = EM.defineComponent2(
+  "_phys",
+  () => {
+    return {
+      // track last stats so we can diff
+      lastLocalPos: PositionDef.construct(),
+      // Colliders
+      // NOTE: these can be many-to-one colliders-to-entities, hence the arrays
+      colliders: [] as PhysCollider[],
+      // TODO(@darzu): use sweepAABBs again?
+    };
+  },
+  (p) => p
+);
 export type PhysicsState = Component<typeof PhysicsStateDef>;
 
 export interface PhysicsObject {

--- a/src/physics/nonintersection.ts
+++ b/src/physics/nonintersection.ts
@@ -34,6 +34,7 @@ import {
   PositionDef,
   ReadonlyFrame,
   TransformDef,
+  createFrame,
   updateFrameFromPosRotScale,
 } from "./transform.js";
 import { IdPair, idPair } from "../utils/util.js";
@@ -54,16 +55,11 @@ export const PhysicsResultsDef = EM.defineResource("physicsResults", () => {
 });
 export type PhysicsResults = Component<typeof PhysicsResultsDef>;
 
-export function createFrame(): Frame {
-  return {
-    position: vec3.create(),
-    rotation: quat.create(),
-    scale: V(1, 1, 1),
-    transform: mat4.create(),
-  };
-}
-
-export const WorldFrameDef = EM.defineComponent("world", () => createFrame());
+export const WorldFrameDef = EM.defineComponent2(
+  "world",
+  () => createFrame(),
+  (p) => p
+);
 
 export interface PhysCollider {
   // NOTE: we use "id" and "aabb" here b/c broadphase looks for a struct with those

--- a/src/physics/nonintersection.ts
+++ b/src/physics/nonintersection.ts
@@ -55,7 +55,7 @@ export const PhysicsResultsDef = EM.defineResource("physicsResults", () => {
 });
 export type PhysicsResults = Component<typeof PhysicsResultsDef>;
 
-export const WorldFrameDef = EM.defineComponent2(
+export const WorldFrameDef = EM.defineComponent(
   "world",
   () => createFrame(),
   (p) => p
@@ -92,7 +92,7 @@ const DUMMY_COLLIDER: PhysCollider = {
 };
 
 // TODO(@darzu): break this up into the specific use cases
-export const PhysicsStateDef = EM.defineComponent2(
+export const PhysicsStateDef = EM.defineComponent(
   "_phys",
   () => {
     return {

--- a/src/physics/nonintersection.ts
+++ b/src/physics/nonintersection.ts
@@ -55,11 +55,7 @@ export const PhysicsResultsDef = EM.defineResource("physicsResults", () => {
 });
 export type PhysicsResults = Component<typeof PhysicsResultsDef>;
 
-export const WorldFrameDef = EM.defineComponent(
-  "world",
-  () => createFrame(),
-  (p) => p
-);
+export const WorldFrameDef = EM.defineComponent("world", () => createFrame());
 
 export interface PhysCollider {
   // NOTE: we use "id" and "aabb" here b/c broadphase looks for a struct with those
@@ -92,20 +88,16 @@ const DUMMY_COLLIDER: PhysCollider = {
 };
 
 // TODO(@darzu): break this up into the specific use cases
-export const PhysicsStateDef = EM.defineComponent(
-  "_phys",
-  () => {
-    return {
-      // track last stats so we can diff
-      lastLocalPos: PositionDef.construct(),
-      // Colliders
-      // NOTE: these can be many-to-one colliders-to-entities, hence the arrays
-      colliders: [] as PhysCollider[],
-      // TODO(@darzu): use sweepAABBs again?
-    };
-  },
-  (p) => p
-);
+export const PhysicsStateDef = EM.defineComponent("_phys", () => {
+  return {
+    // track last stats so we can diff
+    lastLocalPos: PositionDef.construct(),
+    // Colliders
+    // NOTE: these can be many-to-one colliders-to-entities, hence the arrays
+    colliders: [] as PhysCollider[],
+    // TODO(@darzu): use sweepAABBs again?
+  };
+});
 export type PhysicsState = Component<typeof PhysicsStateDef>;
 
 export interface PhysicsObject {

--- a/src/physics/nonintersection.ts
+++ b/src/physics/nonintersection.ts
@@ -244,7 +244,8 @@ export function registerPhysicsStateInit() {
           continue;
         }
         const parentId = PhysicsParentDef.isOn(o) ? o.physicsParent.id : 0;
-        const _phys = EM.addComponent(o.id, PhysicsStateDef);
+        EM.set(o, PhysicsStateDef);
+        const _phys = o._phys;
 
         // AABBs (collider derived)
         // TODO(@darzu): handle scale

--- a/src/physics/phys-debug.ts
+++ b/src/physics/phys-debug.ts
@@ -37,7 +37,7 @@ export const PhysicsDbgDef = EM.defineResource("_physDbgState", () => {
   };
 });
 
-export const DbgMeshDef = EM.defineComponent2(
+export const DbgMeshDef = EM.defineComponent(
   "_physDbgMesh",
   () => {
     return {

--- a/src/physics/phys-debug.ts
+++ b/src/physics/phys-debug.ts
@@ -64,8 +64,8 @@ export function registerPhysicsDebuggerSystem() {
 
             // with a wireframe mesh
             // TODO(@darzu): doesn't work w/o our line renderer
-            EM.addComponent(
-              dbgE.id,
+            EM.set(
+              dbgE,
               RenderableConstructDef,
               res.allMeshes.wireCube.proto,
               res._physDbgState.showAABBs,
@@ -73,7 +73,7 @@ export function registerPhysicsDebuggerSystem() {
             );
 
             // colored
-            EM.addComponent(dbgE.id, ColorDef, V(0, 1, 0));
+            EM.set(dbgE, ColorDef, V(0, 1, 0));
 
             // positioned and scaled
             EM.set(dbgE, PositionDef);
@@ -82,7 +82,7 @@ export function registerPhysicsDebuggerSystem() {
             // NOTE: we don't use the normal parent transform mechanism b/c
             //  colliders especially AABBs are only translated, not full matrix
             //  transform'ed
-            EM.addComponent(dbgE.id, DbgMeshDef, c.id);
+            EM.set(dbgE, DbgMeshDef, c.id);
 
             // remember
             res._physDbgState.colliderMeshes.set(e.id, dbgE.id);

--- a/src/physics/phys-debug.ts
+++ b/src/physics/phys-debug.ts
@@ -76,8 +76,8 @@ export function registerPhysicsDebuggerSystem() {
             EM.addComponent(dbgE.id, ColorDef, V(0, 1, 0));
 
             // positioned and scaled
-            EM.ensureComponentOn(dbgE, PositionDef);
-            EM.ensureComponentOn(dbgE, ScaleDef);
+            EM.set(dbgE, PositionDef);
+            EM.set(dbgE, ScaleDef);
 
             // NOTE: we don't use the normal parent transform mechanism b/c
             //  colliders especially AABBs are only translated, not full matrix

--- a/src/physics/phys-debug.ts
+++ b/src/physics/phys-debug.ts
@@ -37,16 +37,12 @@ export const PhysicsDbgDef = EM.defineResource("_physDbgState", () => {
   };
 });
 
-export const DbgMeshDef = EM.defineComponent(
+export const DbgMeshDef = EM.defineNonupdatableComponent(
   "_physDbgMesh",
-  () => {
+  (colliderId?: number) => {
     return {
-      colliderId: -1,
+      colliderId: colliderId || -1,
     };
-  },
-  (p, colliderId?: number) => {
-    if (colliderId) p.colliderId = colliderId;
-    return p;
   }
 );
 

--- a/src/physics/phys-debug.ts
+++ b/src/physics/phys-debug.ts
@@ -37,12 +37,16 @@ export const PhysicsDbgDef = EM.defineResource("_physDbgState", () => {
   };
 });
 
-export const DbgMeshDef = EM.defineComponent(
+export const DbgMeshDef = EM.defineComponent2(
   "_physDbgMesh",
-  (colliderId?: number) => {
+  () => {
     return {
-      colliderId: colliderId || -1,
+      colliderId: -1,
     };
+  },
+  (p, colliderId?: number) => {
+    if (colliderId) p.colliderId = colliderId;
+    return p;
   }
 );
 

--- a/src/physics/transform.ts
+++ b/src/physics/transform.ts
@@ -82,7 +82,7 @@ export function identityFrame(out: Frame) {
 }
 
 // TRANSFORM
-export const TransformDef = EM.defineComponent2(
+export const TransformDef = EM.defineComponent(
   "transform",
   () => mat4.create(),
   (p, t?: mat4.InputT) => (t ? mat4.copy(p, t) : p)
@@ -90,7 +90,7 @@ export const TransformDef = EM.defineComponent2(
 export type Transform = mat4;
 
 // POSITION
-export const PositionDef = EM.defineComponent2(
+export const PositionDef = EM.defineComponent(
   "position",
   () => V(0, 0, 0),
   (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
@@ -103,7 +103,7 @@ EM.registerSerializerPair(
 );
 
 // ROTATION
-export const RotationDef = EM.defineComponent2(
+export const RotationDef = EM.defineComponent(
   "rotation",
   () => quat.create(),
   (p, r?: quat.InputT) => (r ? quat.copy(p, r) : p)
@@ -116,7 +116,7 @@ EM.registerSerializerPair(
 );
 
 // SCALE
-export const ScaleDef = EM.defineComponent2(
+export const ScaleDef = EM.defineComponent(
   "scale",
   () => V(1, 1, 1),
   (p, by?: vec3.InputT) => (by ? vec3.copy(p, by) : p)
@@ -137,7 +137,7 @@ export const LocalFrameDefs = [
 ] as const;
 
 // PARENT
-export const PhysicsParentDef = EM.defineComponent2(
+export const PhysicsParentDef = EM.defineComponent(
   "physicsParent",
   () => {
     return { id: 0 };

--- a/src/physics/transform.ts
+++ b/src/physics/transform.ts
@@ -1,6 +1,6 @@
 import { Component, EM } from "../ecs/entity-manager.js";
 import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
-import { createFrame, WorldFrameDef } from "./nonintersection.js";
+import { WorldFrameDef } from "./nonintersection.js";
 import { tempVec3, tempQuat } from "../matrix/temp-pool.js";
 import { FALSE, dbgLogOnce } from "../utils/util.js";
 import { Phase } from "../ecs/sys-phase.js";
@@ -57,6 +57,14 @@ export function updateFrameFromPosRotScale(f: Frame) {
     f.scale,
     f.transform
   );
+}
+export function createFrame(): Frame {
+  return {
+    position: vec3.create(),
+    rotation: quat.create(),
+    scale: V(1, 1, 1),
+    transform: mat4.create(),
+  };
 }
 
 export function copyFrame(out: Frame, frame: Frame) {

--- a/src/physics/transform.ts
+++ b/src/physics/transform.ts
@@ -82,15 +82,18 @@ export function identityFrame(out: Frame) {
 }
 
 // TRANSFORM
-export const TransformDef = EM.defineComponent("transform", (t?: mat4) => {
-  return t ?? mat4.create();
-});
+export const TransformDef = EM.defineComponent2(
+  "transform",
+  () => mat4.create(),
+  (p, t?: mat4.InputT) => (t ? mat4.copy(p, t) : p)
+);
 export type Transform = mat4;
 
 // POSITION
-export const PositionDef = EM.defineComponent(
+export const PositionDef = EM.defineComponent2(
   "position",
-  (p?: vec3) => p || V(0, 0, 0)
+  () => V(0, 0, 0),
+  (p, v?: vec3.InputT) => (v ? vec3.copy(p, v) : p)
 );
 export type Position = Component<typeof PositionDef>;
 EM.registerSerializerPair(
@@ -100,9 +103,10 @@ EM.registerSerializerPair(
 );
 
 // ROTATION
-export const RotationDef = EM.defineComponent(
+export const RotationDef = EM.defineComponent2(
   "rotation",
-  (r?: quat) => r || quat.create()
+  () => quat.create(),
+  (p, r?: quat.InputT) => (r ? quat.copy(p, r) : p)
 );
 export type Rotation = Component<typeof RotationDef>;
 EM.registerSerializerPair(
@@ -112,9 +116,10 @@ EM.registerSerializerPair(
 );
 
 // SCALE
-export const ScaleDef = EM.defineComponent(
+export const ScaleDef = EM.defineComponent2(
   "scale",
-  (by?: vec3) => by || V(1, 1, 1)
+  () => V(1, 1, 1),
+  (p, by?: vec3.InputT) => (by ? vec3.copy(p, by) : p)
 );
 export type Scale = Component<typeof ScaleDef>;
 EM.registerSerializerPair(
@@ -132,10 +137,14 @@ export const LocalFrameDefs = [
 ] as const;
 
 // PARENT
-export const PhysicsParentDef = EM.defineComponent(
+export const PhysicsParentDef = EM.defineComponent2(
   "physicsParent",
-  (p?: number) => {
-    return { id: p || 0 };
+  () => {
+    return { id: 0 };
+  },
+  (p, parentId?: number) => {
+    if (parentId) p.id = parentId;
+    return p;
   }
 );
 export type PhysicsParent = Component<typeof PhysicsParentDef>;

--- a/src/physics/transform.ts
+++ b/src/physics/transform.ts
@@ -201,7 +201,7 @@ export function registerInitTransforms() {
     (objs) => {
       for (let o of objs) {
         if (!WorldFrameDef.isOn(o)) {
-          EM.ensureComponentOn(o, WorldFrameDef);
+          EM.set(o, WorldFrameDef);
           copyFrame(o.world, o);
         }
       }
@@ -225,10 +225,10 @@ export function registerUpdateLocalFromPosRotScale() {
           ScaleDef.isOn(o) ||
           TransformDef.isOn(o)
         ) {
-          EM.ensureComponentOn(o, PositionDef);
-          EM.ensureComponentOn(o, RotationDef);
-          EM.ensureComponentOn(o, ScaleDef);
-          EM.ensureComponentOn(o, TransformDef);
+          EM.set(o, PositionDef);
+          EM.set(o, RotationDef);
+          EM.set(o, ScaleDef);
+          EM.set(o, TransformDef);
         }
       }
     }

--- a/src/render/game-shading.ts
+++ b/src/render/game-shading.ts
@@ -93,37 +93,37 @@ export async function initShadingGame() {
 
   // light
   const sun = EM.new();
-  EM.ensureComponentOn(sun, PointLightDef);
-  EM.ensureComponentOn(sun, ColorDef, V(1, 1, 1));
+  EM.set(sun, PointLightDef);
+  EM.set(sun, ColorDef, V(1, 1, 1));
   // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
   // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
-  EM.ensureComponentOn(sun, PositionDef, V(100, 100, 100));
-  EM.ensureComponentOn(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
-  EM.ensureComponentOn(sun, RenderableConstructDef, sg_meshes.cube.proto);
+  EM.set(sun, PositionDef, V(100, 100, 100));
+  EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
+  EM.set(sun, RenderableConstructDef, sg_meshes.cube.proto);
   sun.pointLight.constant = 1.0;
   sun.pointLight.linear = 0.0;
   sun.pointLight.quadratic = 0.0;
   vec3.copy(sun.pointLight.ambient, [0.2, 0.2, 0.2]);
   vec3.copy(sun.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sun, PositionDef, V(50, 300, 10));
+  EM.set(sun, PositionDef, V(50, 300, 10));
 
   // ground
   const ground = EM.new();
-  EM.ensureComponentOn(ground, RenderableConstructDef, sg_meshes.hex.proto);
-  EM.ensureComponentOn(ground, ColorDef, ENDESGA16.blue);
-  EM.ensureComponentOn(ground, PositionDef, V(0, -10, 0));
-  EM.ensureComponentOn(ground, ScaleDef, V(10, 10, 10));
+  EM.set(ground, RenderableConstructDef, sg_meshes.hex.proto);
+  EM.set(ground, ColorDef, ENDESGA16.blue);
+  EM.set(ground, PositionDef, V(0, -10, 0));
+  EM.set(ground, ScaleDef, V(10, 10, 10));
 
   // gizmo
   const gizmoMesh = createGizmoMesh();
   const gizmo = EM.new();
-  EM.ensureComponentOn(gizmo, RenderableConstructDef, gizmoMesh);
-  EM.ensureComponentOn(gizmo, PositionDef, V(0, 1, 0));
+  EM.set(gizmo, RenderableConstructDef, gizmoMesh);
+  EM.set(gizmo, PositionDef, V(0, 1, 0));
 
   // avatar
   const g = createGhost();
   g.position[1] = 5;
-  EM.ensureComponentOn(g, RenderableConstructDef, sg_meshes.ball.proto);
+  EM.set(g, RenderableConstructDef, sg_meshes.ball.proto);
   // vec3.copy(g.position, [2.44, 6.81, 0.96]);
   // quat.copy(g.rotation, [0.0, 0.61, 0.0, 0.79]);
   // g.cameraFollow.pitchOffset = -0.553;
@@ -135,10 +135,10 @@ export async function initShadingGame() {
 
   // objects
   const obj = EM.new();
-  EM.ensureComponentOn(obj, RenderableConstructDef, sg_meshes.grappleGun.proto);
-  EM.ensureComponentOn(obj, PositionDef, V(0, 4, 0));
-  EM.ensureComponentOn(obj, ColorDef, ENDESGA16.midBrown);
-  EM.ensureComponentOn(obj, AngularVelocityDef, V(0.001, 0.00013, 0.00017));
+  EM.set(obj, RenderableConstructDef, sg_meshes.grappleGun.proto);
+  EM.set(obj, PositionDef, V(0, 4, 0));
+  EM.set(obj, ColorDef, ENDESGA16.midBrown);
+  EM.set(obj, AngularVelocityDef, V(0.001, 0.00013, 0.00017));
 
   // frustum debugging
   {
@@ -148,9 +148,9 @@ export async function initShadingGame() {
       const pos = V(jitter(W), jitter(W) + W, jitter(W));
       worldCorners.push(pos);
       const p = EM.new();
-      EM.ensureComponentOn(p, RenderableConstructDef, sg_meshes.ball.proto);
-      EM.ensureComponentOn(p, PositionDef, pos);
-      EM.ensureComponentOn(p, ColorDef, V(0, 1, 0));
+      EM.set(p, RenderableConstructDef, sg_meshes.ball.proto);
+      EM.set(p, PositionDef, pos);
+      EM.set(p, ColorDef, V(0, 1, 0));
     }
 
     // TODO(@darzu): IMPORTANT. figure out mat4.perspective's clip-space!
@@ -163,15 +163,15 @@ export async function initShadingGame() {
     const frustCorners = getFrustumWorldCorners(invFrust);
     for (let i = 0; i < frustCorners.length; i++) {
       const p = EM.new();
-      EM.ensureComponentOn(p, RenderableConstructDef, sg_meshes.ball.proto);
-      EM.ensureComponentOn(p, PositionDef, vec3.clone(frustCorners[i]));
-      EM.ensureComponentOn(p, ColorDef, V(1, 0, 0));
+      EM.set(p, RenderableConstructDef, sg_meshes.ball.proto);
+      EM.set(p, PositionDef, vec3.clone(frustCorners[i]));
+      EM.set(p, ColorDef, V(1, 0, 0));
     }
     const frustGizMesh = createGizmoMesh();
     mapMeshPositions(frustGizMesh, (p) => vec3.transformMat4(p, invFrust, p));
     const frustGiz = EM.new();
-    EM.ensureComponentOn(frustGiz, RenderableConstructDef, frustGizMesh);
-    EM.ensureComponentOn(frustGiz, PositionDef, V(0, 0, 0));
+    EM.set(frustGiz, RenderableConstructDef, frustGizMesh);
+    EM.set(frustGiz, PositionDef, V(0, 0, 0));
 
     // const frust2 = mat4.create();
     // positionAndTargetToOrthoViewProjMatrix(frust2, sun.position, V(0, 0, 0));

--- a/src/render/game-shading.ts
+++ b/src/render/game-shading.ts
@@ -95,8 +95,8 @@ export async function initShadingGame() {
   const sun = EM.new();
   EM.set(sun, PointLightDef);
   EM.set(sun, ColorDef, V(1, 1, 1));
-  // EM.ensureComponentOn(sun, PositionDef, V(100, 100, 0));
-  // EM.ensureComponentOn(sun, PositionDef, V(-10, 10, 10));
+  // EM.set(sun, PositionDef, V(100, 100, 0));
+  // EM.set(sun, PositionDef, V(-10, 10, 10));
   EM.set(sun, PositionDef, V(100, 100, 100));
   EM.set(sun, LinearVelocityDef, V(0.001, 0.001, 0.0));
   EM.set(sun, RenderableConstructDef, sg_meshes.cube.proto);
@@ -179,16 +179,16 @@ export async function initShadingGame() {
     // const frustGiz2Mesh = createGizmoMesh();
     // mapMeshPositions(frustGiz2Mesh, (p) => vec3.transformMat4(p, invFrust2, p));
     // const frustGiz2 = EM.new();
-    // EM.ensureComponentOn(frustGiz2, RenderableConstructDef, frustGiz2Mesh);
-    // EM.ensureComponentOn(frustGiz2, PositionDef, V(0, 0, 0));
+    // EM.set(frustGiz2, RenderableConstructDef, frustGiz2Mesh);
+    // EM.set(frustGiz2, PositionDef, V(0, 0, 0));
   }
 
   // const myViewCorners: EntityW<[typeof PositionDef]>[] = [];
   // for (let i = 0; i < 8; i++) {
   //   const p = EM.new();
-  //   EM.ensureComponentOn(p, RenderableConstructDef, sg_meshes.ball.proto);
-  //   EM.ensureComponentOn(p, PositionDef);
-  //   EM.ensureComponentOn(p, ColorDef, V(0, 1, 1));
+  //   EM.set(p, RenderableConstructDef, sg_meshes.ball.proto);
+  //   EM.set(p, PositionDef);
+  //   EM.set(p, ColorDef, V(0, 1, 1));
   //   myViewCorners.push(p);
   // }
   // EM.registerSystem(

--- a/src/render/gpu-registry.ts
+++ b/src/render/gpu-registry.ts
@@ -126,7 +126,8 @@ export interface CyMeshPoolPtr<
   setMaxLines: number;
   setMaxVerts: number;
   // TODO(@darzu): really unsure how I feel about having an EM component here in CY
-  dataDef: ComponentDef<string, CyToTS<U>, [Mesh]>;
+  // TODO(@darzu): REFACTOR FIX! Should have CArgs, not UArgs
+  dataDef: ComponentDef<string, CyToTS<U>, [], [Mesh]>;
 }
 
 // PIPELINES

--- a/src/render/gpu-registry.ts
+++ b/src/render/gpu-registry.ts
@@ -321,6 +321,8 @@ export function createCytochromeRegistry() {
 
   // TODO(@darzu): rename all "createX" to "mkX" for brevity?
   return {
+    // TODO(@darzu): HACK. We want to support multiple instantiation points!
+    _hasBeenInstantiated: false,
     nameToPtr,
     kindToPtrs: nextFlightPtrs,
     createSingleton: <O extends CyStructDesc>(

--- a/src/render/gpu-registry.ts
+++ b/src/render/gpu-registry.ts
@@ -117,6 +117,7 @@ export interface CyMeshPoolPtr<
   kind: "meshPool";
   // TODO(@darzu): remove id and name, this doesn't need to be inited directly
   computeVertsData: ComputeVertsDataFn<V>;
+  computeUniData: (m: Mesh) => CyToTS<U>;
   vertsStruct: CyStruct<V>;
   unisStruct: CyStruct<U>;
   // TODO(@darzu): do we need these max's? maybe we make them optional
@@ -126,8 +127,7 @@ export interface CyMeshPoolPtr<
   setMaxLines: number;
   setMaxVerts: number;
   // TODO(@darzu): really unsure how I feel about having an EM component here in CY
-  // TODO(@darzu): REFACTOR FIX! Should have CArgs, not UArgs
-  dataDef: ComponentDef<string, CyToTS<U>, [], [Mesh]>;
+  dataDef: ComponentDef<string, CyToTS<U>, [CyToTS<U>], []>;
 }
 
 // PIPELINES

--- a/src/render/gpu-registry.ts
+++ b/src/render/gpu-registry.ts
@@ -117,7 +117,6 @@ export interface CyMeshPoolPtr<
   kind: "meshPool";
   // TODO(@darzu): remove id and name, this doesn't need to be inited directly
   computeVertsData: ComputeVertsDataFn<V>;
-  computeUniData: (m: Mesh) => CyToTS<U>;
   vertsStruct: CyStruct<V>;
   unisStruct: CyStruct<U>;
   // TODO(@darzu): do we need these max's? maybe we make them optional
@@ -127,7 +126,7 @@ export interface CyMeshPoolPtr<
   setMaxLines: number;
   setMaxVerts: number;
   // TODO(@darzu): really unsure how I feel about having an EM component here in CY
-  dataDef: ComponentDef<string, CyToTS<U>, [CyToTS<U>]>;
+  dataDef: ComponentDef<string, CyToTS<U>, [Mesh]>;
 }
 
 // PIPELINES

--- a/src/render/instantiator-webgpu.ts
+++ b/src/render/instantiator-webgpu.ts
@@ -224,6 +224,9 @@ export function createCyResources(
 ): CyResources {
   const start = performance.now();
 
+  // TODO(@darzu): HACK. we want to support multiple instantiation times
+  cy._hasBeenInstantiated = true;
+
   const bufferUsages = collectBufferUsages(cy);
   const textureUsages = collectTextureUsages(cy);
 

--- a/src/render/lights.ts
+++ b/src/render/lights.ts
@@ -49,7 +49,7 @@ function createDefaultPointLight(): PointLightTS {
   };
 }
 
-export const PointLightDef = EM.defineComponent2(
+export const PointLightDef = EM.defineComponent(
   "pointLight",
   createDefaultPointLight,
   (p) => p

--- a/src/render/lights.ts
+++ b/src/render/lights.ts
@@ -49,9 +49,10 @@ function createDefaultPointLight(): PointLightTS {
   };
 }
 
-export const PointLightDef = EM.defineComponent(
+export const PointLightDef = EM.defineComponent2(
   "pointLight",
-  createDefaultPointLight
+  createDefaultPointLight,
+  (p) => p
 );
 
 export const pointLightsPtr = CY.createArray("pointLight", {

--- a/src/render/lights.ts
+++ b/src/render/lights.ts
@@ -51,8 +51,7 @@ function createDefaultPointLight(): PointLightTS {
 
 export const PointLightDef = EM.defineComponent(
   "pointLight",
-  createDefaultPointLight,
-  (p) => p
+  createDefaultPointLight
 );
 
 export const pointLightsPtr = CY.createArray("pointLight", {

--- a/src/render/mesh-pool.ts
+++ b/src/render/mesh-pool.ts
@@ -18,7 +18,6 @@ import {
 } from "./gpu-registry.js";
 import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
 import { DEFAULT_MASK } from "./pipeline-masks.js";
-import { ComponentDef } from "../ecs/entity-manager.js";
 import { GPUBufferUsage } from "./webgpu-hacks.js";
 import { CyResources } from "./instantiator-webgpu.js";
 
@@ -410,7 +409,9 @@ export function createMeshPool<V extends CyStructDesc, U extends CyStructDesc>(
     if (m.pos.length) updateMeshVertices(handle, m);
     // TODO(@darzu): this is duplicating the uniform that will also (probably) be stored
     //  in the data component.
-    const uni = ptr.dataDef.construct(m); // TODO(@darzu): hacky to use ECS fns here
+    // TODO(@darzu): REFACTOR. Shouldn't use update here. hsould be non-updatable
+    let uni = ptr.dataDef.construct();
+    ptr.dataDef.update(uni, m); // TODO(@darzu): hacky to use ECS fns here
     updateUniform(handle, uni);
 
     return handle;

--- a/src/render/mesh-pool.ts
+++ b/src/render/mesh-pool.ts
@@ -408,7 +408,9 @@ export function createMeshPool<V extends CyStructDesc, U extends CyStructDesc>(
     if (m.quad.length) updateMeshQuads(handle, m);
     if (m.tri.length) updateMeshTriangles(handle, m);
     if (m.pos.length) updateMeshVertices(handle, m);
-    const uni = ptr.computeUniData(m);
+    // TODO(@darzu): this is duplicating the uniform that will also (probably) be stored
+    //  in the data component.
+    const uni = ptr.dataDef.construct(m); // TODO(@darzu): hacky to use ECS fns here
     updateUniform(handle, uni);
 
     return handle;

--- a/src/render/mesh-pool.ts
+++ b/src/render/mesh-pool.ts
@@ -18,6 +18,7 @@ import {
 } from "./gpu-registry.js";
 import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
 import { DEFAULT_MASK } from "./pipeline-masks.js";
+import { ComponentDef } from "../ecs/entity-manager.js";
 import { GPUBufferUsage } from "./webgpu-hacks.js";
 import { CyResources } from "./instantiator-webgpu.js";
 
@@ -407,11 +408,9 @@ export function createMeshPool<V extends CyStructDesc, U extends CyStructDesc>(
     if (m.quad.length) updateMeshQuads(handle, m);
     if (m.tri.length) updateMeshTriangles(handle, m);
     if (m.pos.length) updateMeshVertices(handle, m);
-    // TODO(@darzu): this is duplicating the uniform that will also (probably) be stored
+    // TODO(@darzu): PERF. this is duplicating the uniform that will also (probably) be stored
     //  in the data component.
-    // TODO(@darzu): REFACTOR. Shouldn't use update here. hsould be non-updatable
-    let uni = ptr.dataDef.construct();
-    ptr.dataDef.update(uni, m); // TODO(@darzu): hacky to use ECS fns here
+    const uni = ptr.computeUniData(m);
     updateUniform(handle, uni);
 
     return handle;

--- a/src/render/motion-smoothing.ts
+++ b/src/render/motion-smoothing.ts
@@ -33,21 +33,17 @@ export function setSimulationAlpha(to: number) {
   _simulationAlpha = to;
 }
 
-export const MotionSmoothingDef = EM.defineComponent(
-  "motionSmoothing",
-  () => {
-    return {
-      havePrevious: false,
-      prevParentId: 0,
-      prevPosition: vec3.create(),
-      prevRotation: quat.create(),
+export const MotionSmoothingDef = EM.defineComponent("motionSmoothing", () => {
+  return {
+    havePrevious: false,
+    prevParentId: 0,
+    prevPosition: vec3.create(),
+    prevRotation: quat.create(),
 
-      positionError: vec3.create(),
-      rotationError: quat.create(),
-    };
-  },
-  (p) => p
-);
+    positionError: vec3.create(),
+    rotationError: quat.create(),
+  };
+});
 export type MotionSmoothing = Component<typeof MotionSmoothingDef>;
 
 export function initNetMotionRecordingSystem() {
@@ -75,14 +71,12 @@ const _hasRendererWorldFrame = new Set();
 
 export const SmoothedWorldFrameDef = EM.defineComponent(
   "smoothedWorldFrame",
-  () => createFrame(),
-  (p) => p
+  () => createFrame()
 );
 
 export const PrevSmoothedWorldFrameDef = EM.defineComponent(
   "prevSmoothedWorldFrame",
-  () => createFrame(),
-  (p) => p
+  () => createFrame()
 );
 
 function updateSmoothedWorldFrame(o: Entity) {

--- a/src/render/motion-smoothing.ts
+++ b/src/render/motion-smoothing.ts
@@ -10,6 +10,7 @@ import {
   updateFrameFromPosRotScale,
   updateFrameFromTransform,
   Frame,
+  createFrame,
 } from "../physics/transform.js";
 import { computeNewError, reduceError } from "../utils/smoothing.js";
 import { RemoteUpdatesDef } from "../net/components.js";
@@ -17,7 +18,7 @@ import { Phase } from "../ecs/sys-phase.js";
 import { RenderableDef, RendererWorldFrameDef } from "./renderer-ecs.js";
 import { DONT_SMOOTH_WORLD_FRAME } from "../flags.js";
 import { DeletedDef } from "../ecs/delete.js";
-import { WorldFrameDef, createFrame } from "../physics/nonintersection.js";
+import { WorldFrameDef } from "../physics/nonintersection.js";
 import { tempVec3 } from "../matrix/temp-pool.js";
 
 // Determined via binary search--smaller -> jerky, larger -> floaty

--- a/src/render/motion-smoothing.ts
+++ b/src/render/motion-smoothing.ts
@@ -92,8 +92,8 @@ function updateSmoothedWorldFrame(o: Entity) {
   }
   let firstFrame = false;
   if (!SmoothedWorldFrameDef.isOn(o)) firstFrame = true;
-  EM.ensureComponentOn(o, SmoothedWorldFrameDef);
-  EM.ensureComponentOn(o, PrevSmoothedWorldFrameDef);
+  EM.set(o, SmoothedWorldFrameDef);
+  EM.set(o, PrevSmoothedWorldFrameDef);
   copyFrame(o.prevSmoothedWorldFrame, o.smoothedWorldFrame);
   mat4.copy(o.smoothedWorldFrame.transform, o.transform);
   updateFrameFromTransform(o.smoothedWorldFrame);
@@ -185,8 +185,8 @@ export function initMotionSmoothingSystems() {
       for (const o of objs) {
         // TODO(@darzu): PERF HACK!
         if (DONT_SMOOTH_WORLD_FRAME) {
-          EM.ensureComponentOn(o, SmoothedWorldFrameDef);
-          EM.ensureComponentOn(o, PrevSmoothedWorldFrameDef);
+          EM.set(o, SmoothedWorldFrameDef);
+          EM.set(o, PrevSmoothedWorldFrameDef);
           continue;
         }
 
@@ -205,14 +205,14 @@ export function initMotionSmoothingSystems() {
         if (DONT_SMOOTH_WORLD_FRAME) {
           // TODO(@darzu): HACK!
           if (WorldFrameDef.isOn(o)) {
-            EM.ensureComponentOn(o, RendererWorldFrameDef);
+            EM.set(o, RendererWorldFrameDef);
             copyFrame(o.rendererWorldFrame, o.world);
             // (o as any).rendererWorldFrame = o.world;
           }
           continue;
         }
 
-        EM.ensureComponentOn(o, RendererWorldFrameDef);
+        EM.set(o, RendererWorldFrameDef);
 
         switch (BLEND_SIMULATION_FRAMES_STRATEGY) {
           case "interpolate":

--- a/src/render/motion-smoothing.ts
+++ b/src/render/motion-smoothing.ts
@@ -33,17 +33,21 @@ export function setSimulationAlpha(to: number) {
   _simulationAlpha = to;
 }
 
-export const MotionSmoothingDef = EM.defineComponent("motionSmoothing", () => {
-  return {
-    havePrevious: false,
-    prevParentId: 0,
-    prevPosition: vec3.create(),
-    prevRotation: quat.create(),
+export const MotionSmoothingDef = EM.defineComponent2(
+  "motionSmoothing",
+  () => {
+    return {
+      havePrevious: false,
+      prevParentId: 0,
+      prevPosition: vec3.create(),
+      prevRotation: quat.create(),
 
-    positionError: vec3.create(),
-    rotationError: quat.create(),
-  };
-});
+      positionError: vec3.create(),
+      rotationError: quat.create(),
+    };
+  },
+  (p) => p
+);
 export type MotionSmoothing = Component<typeof MotionSmoothingDef>;
 
 export function initNetMotionRecordingSystem() {
@@ -69,14 +73,16 @@ export function initNetMotionRecordingSystem() {
 
 const _hasRendererWorldFrame = new Set();
 
-export const SmoothedWorldFrameDef = EM.defineComponent(
+export const SmoothedWorldFrameDef = EM.defineComponent2(
   "smoothedWorldFrame",
-  () => createFrame()
+  () => createFrame(),
+  (p) => p
 );
 
-export const PrevSmoothedWorldFrameDef = EM.defineComponent(
+export const PrevSmoothedWorldFrameDef = EM.defineComponent2(
   "prevSmoothedWorldFrame",
-  () => createFrame()
+  () => createFrame(),
+  (p) => p
 );
 
 function updateSmoothedWorldFrame(o: Entity) {

--- a/src/render/motion-smoothing.ts
+++ b/src/render/motion-smoothing.ts
@@ -33,7 +33,7 @@ export function setSimulationAlpha(to: number) {
   _simulationAlpha = to;
 }
 
-export const MotionSmoothingDef = EM.defineComponent2(
+export const MotionSmoothingDef = EM.defineComponent(
   "motionSmoothing",
   () => {
     return {
@@ -73,13 +73,13 @@ export function initNetMotionRecordingSystem() {
 
 const _hasRendererWorldFrame = new Set();
 
-export const SmoothedWorldFrameDef = EM.defineComponent2(
+export const SmoothedWorldFrameDef = EM.defineComponent(
   "smoothedWorldFrame",
   () => createFrame(),
   (p) => p
 );
 
-export const PrevSmoothedWorldFrameDef = EM.defineComponent2(
+export const PrevSmoothedWorldFrameDef = EM.defineComponent(
   "prevSmoothedWorldFrame",
   () => createFrame(),
   (p) => p

--- a/src/render/pipelines/std-compose.ts
+++ b/src/render/pipelines/std-compose.ts
@@ -1,5 +1,7 @@
+import { assert } from "../../utils/util.js";
 import { createRenderTextureToQuad } from "../gpu-helper.js";
 import {
+  CY,
   CyDepthAttachment,
   CyDepthTexturePtr,
   CyRenderPipelinePtr,
@@ -15,6 +17,10 @@ let __nextGridId = 1;
 export function createGridComposePipelines(
   grid: (CyTexturePtr | CyDepthAttachment)[][]
 ): CyRenderPipelinePtr[] {
+  assert(
+    !CY._hasBeenInstantiated,
+    `CY already instantiated; TODO: support multiple instantiations`
+  );
   const width = grid[0].length;
   const height = grid.length;
   const uvWidth = (2.0 - padding * (width + 1)) / width;

--- a/src/render/pipelines/std-ocean.ts
+++ b/src/render/pipelines/std-ocean.ts
@@ -142,28 +142,30 @@ function computeOceanVertsData(
   return vertsData;
 }
 
-export function computeOceanUniData(m: Mesh): OceanUniTS {
-  // TODO(@darzu): change
-  const { min, max } = getAABBFromMesh(m);
+export function createOceanUniData(): OceanUniTS {
   const uni: OceanUniTS = {
     transform: mat4.create(),
-    aabbMin: min,
-    aabbMax: max,
+    aabbMin: V(Infinity, Infinity, Infinity),
+    aabbMax: V(-Infinity, -Infinity, -Infinity),
     tint: vec3.create(),
     id: 0,
   };
   return uni;
 }
+export function updateOceanUniData(u: OceanUniTS, m: Mesh): OceanUniTS {
+  const { min, max } = getAABBFromMesh(m);
+  vec3.copy(u.aabbMin, min);
+  vec3.copy(u.aabbMax, max);
+  return u;
+}
 
-export const RenderDataOceanDef = EM.defineComponent(
+export const RenderDataOceanDef = EM.defineComponent2(
   "renderDataOcean",
-  (r: OceanUniTS) => r
+  createOceanUniData,
+  updateOceanUniData
 );
 export const oceanPoolPtr = CY.createMeshPool("oceanPool", {
   computeVertsData: computeOceanVertsData,
-  // TODO(@darzu): per-mesh unis should maybe be optional? I don't think
-  //     the ocean needs them
-  computeUniData: computeOceanUniData,
   unisStruct: OceanUniStruct,
   vertsStruct: OceanVertStruct,
   maxMeshes: MAX_OCEAN_MESHES,

--- a/src/render/pipelines/std-ocean.ts
+++ b/src/render/pipelines/std-ocean.ts
@@ -159,7 +159,7 @@ export function updateOceanUniData(u: OceanUniTS, m: Mesh): OceanUniTS {
   return u;
 }
 
-export const RenderDataOceanDef = EM.defineComponent2(
+export const RenderDataOceanDef = EM.defineComponent(
   "renderDataOcean",
   createOceanUniData,
   updateOceanUniData

--- a/src/render/pipelines/std-ocean.ts
+++ b/src/render/pipelines/std-ocean.ts
@@ -142,30 +142,26 @@ function computeOceanVertsData(
   return vertsData;
 }
 
-export function createOceanUniData(): OceanUniTS {
+export function computeOceanUniData(m: Mesh): OceanUniTS {
+  // TODO(@darzu): change
+  const { min, max } = getAABBFromMesh(m);
   const uni: OceanUniTS = {
     transform: mat4.create(),
-    aabbMin: V(Infinity, Infinity, Infinity),
-    aabbMax: V(-Infinity, -Infinity, -Infinity),
+    aabbMin: min,
+    aabbMax: max,
     tint: vec3.create(),
     id: 0,
   };
   return uni;
 }
-export function updateOceanUniData(u: OceanUniTS, m: Mesh): OceanUniTS {
-  const { min, max } = getAABBFromMesh(m);
-  vec3.copy(u.aabbMin, min);
-  vec3.copy(u.aabbMax, max);
-  return u;
-}
 
-export const RenderDataOceanDef = EM.defineComponent(
+export const RenderDataOceanDef = EM.defineNonupdatableComponent(
   "renderDataOcean",
-  createOceanUniData,
-  updateOceanUniData
+  (r: OceanUniTS) => r
 );
 export const oceanPoolPtr = CY.createMeshPool("oceanPool", {
   computeVertsData: computeOceanVertsData,
+  computeUniData: computeOceanUniData,
   unisStruct: OceanUniStruct,
   vertsStruct: OceanVertStruct,
   maxMeshes: MAX_OCEAN_MESHES,

--- a/src/render/pipelines/std-rigged.ts
+++ b/src/render/pipelines/std-rigged.ts
@@ -109,7 +109,6 @@ const jointBufPtr = CY.createArray("joint", {
 
 const poolPtr = CY.createMeshPool("riggedMeshPool", {
   computeVertsData,
-  computeUniData,
   vertsStruct: VertexStruct,
   unisStruct: MeshUniformStruct,
   maxMeshes: MAX_MESHES,
@@ -121,22 +120,6 @@ const poolPtr = CY.createMeshPool("riggedMeshPool", {
   // TODO(@darzu): this dataDef is v weird
   dataDef: RenderDataStdDef,
 });
-
-// TODO: does this need to be passed into the mesh pool anymore?
-function computeUniData(m: Mesh): MeshUniformTS {
-  const { min, max } = getAABBFromMesh(m);
-  const uni: MeshUniformTS = {
-    transform: mat4.create(),
-    // TODO(@darzu): option for aabbs?
-    // aabbMin: min,
-    // aabbMax: max,
-    tint: vec3.create(),
-    alpha: 1.0,
-    id: 0,
-    flags: 0,
-  };
-  return uni;
-}
 
 // TODO: avoid duplicating std-scene
 // TODO(@darzu): Allow updates directly to serialized data

--- a/src/render/pipelines/std-rigged.ts
+++ b/src/render/pipelines/std-rigged.ts
@@ -13,6 +13,7 @@ import {
   RiggedMesh,
 } from "../../meshes/mesh.js";
 import {
+  computeUniData,
   mainDepthTex,
   MeshUniformStruct,
   MeshUniformTS,
@@ -109,6 +110,7 @@ const jointBufPtr = CY.createArray("joint", {
 
 const poolPtr = CY.createMeshPool("riggedMeshPool", {
   computeVertsData,
+  computeUniData,
   vertsStruct: VertexStruct,
   unisStruct: MeshUniformStruct,
   maxMeshes: MAX_MESHES,

--- a/src/render/pipelines/std-scene.ts
+++ b/src/render/pipelines/std-scene.ts
@@ -83,7 +83,7 @@ export const FLAG_UNLIT = 1;
 
 export type MeshUniformTS = CyToTS<typeof MeshUniformStruct.desc>;
 
-export const RenderDataStdDef = EM.defineComponent2(
+export const RenderDataStdDef = EM.defineComponent(
   "renderDataStd",
   createUniData,
   updateUniData

--- a/src/render/pipelines/std-scene.ts
+++ b/src/render/pipelines/std-scene.ts
@@ -83,13 +83,13 @@ export const FLAG_UNLIT = 1;
 
 export type MeshUniformTS = CyToTS<typeof MeshUniformStruct.desc>;
 
-export const RenderDataStdDef = EM.defineComponent(
+export const RenderDataStdDef = EM.defineNonupdatableComponent(
   "renderDataStd",
-  createUniData,
-  updateUniData
+  (r: MeshUniformTS) => r
 );
 export const meshPoolPtr = CY.createMeshPool("meshPool", {
   computeVertsData,
+  computeUniData,
   vertsStruct: VertexStruct,
   unisStruct: MeshUniformStruct,
   maxMeshes: MAX_MESHES,
@@ -103,7 +103,8 @@ export const meshPoolPtr = CY.createMeshPool("meshPool", {
 });
 
 // TODO: does this need to be passed into the mesh pool anymore?
-export function createUniData(): MeshUniformTS {
+export function computeUniData(m: Mesh): MeshUniformTS {
+  // const { min, max } = getAABBFromMesh(m);
   const uni: MeshUniformTS = {
     transform: mat4.create(),
     // TODO(@darzu): option for aabbs?
@@ -115,10 +116,6 @@ export function createUniData(): MeshUniformTS {
     flags: 0,
   };
   return uni;
-}
-export function updateUniData(u: MeshUniformTS, m: Mesh): MeshUniformTS {
-  // const { min, max } = getAABBFromMesh(m);
-  return u;
 }
 
 // TODO(@darzu): Allow updates directly to serialized data

--- a/src/render/pipelines/std-scene.ts
+++ b/src/render/pipelines/std-scene.ts
@@ -83,13 +83,13 @@ export const FLAG_UNLIT = 1;
 
 export type MeshUniformTS = CyToTS<typeof MeshUniformStruct.desc>;
 
-export const RenderDataStdDef = EM.defineComponent(
+export const RenderDataStdDef = EM.defineComponent2(
   "renderDataStd",
-  (r: MeshUniformTS) => r
+  createUniData,
+  updateUniData
 );
 export const meshPoolPtr = CY.createMeshPool("meshPool", {
   computeVertsData,
-  computeUniData,
   vertsStruct: VertexStruct,
   unisStruct: MeshUniformStruct,
   maxMeshes: MAX_MESHES,
@@ -103,8 +103,7 @@ export const meshPoolPtr = CY.createMeshPool("meshPool", {
 });
 
 // TODO: does this need to be passed into the mesh pool anymore?
-export function computeUniData(m: Mesh): MeshUniformTS {
-  const { min, max } = getAABBFromMesh(m);
+export function createUniData(): MeshUniformTS {
   const uni: MeshUniformTS = {
     transform: mat4.create(),
     // TODO(@darzu): option for aabbs?
@@ -116,6 +115,10 @@ export function computeUniData(m: Mesh): MeshUniformTS {
     flags: 0,
   };
   return uni;
+}
+export function updateUniData(u: MeshUniformTS, m: Mesh): MeshUniformTS {
+  // const { min, max } = getAABBFromMesh(m);
+  return u;
 }
 
 // TODO(@darzu): Allow updates directly to serialized data

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -200,7 +200,7 @@ EM.addEagerInit([RenderableConstructDef], [RendererDef], [], () => {
             meshHandle.mask = e.renderableConstruct.mask;
           }
 
-          EM.addComponent(e.id, RenderableDef, {
+          EM.set(e, RenderableDef, {
             enabled: e.renderableConstruct.enabled,
             hidden: false,
             sortLayer: e.renderableConstruct.sortLayer,
@@ -446,14 +446,14 @@ EM.addEagerInit([RiggedRenderableConstructDef], [RendererDef], [], (res) => {
           assert(pool);
           let meshHandle = pool.addRiggedMesh(mesh);
 
-          EM.addComponent(e.id, RenderableDef, {
+          EM.set(e, RenderableDef, {
             enabled: true,
             hidden: false,
             sortLayer: 0,
             meshHandle,
           });
 
-          EM.addComponent(e.id, RiggedRenderableDef, meshHandle, mesh.rigging);
+          EM.set(e, RiggedRenderableDef, meshHandle, mesh.rigging);
 
           // TODO(@darzu): de-duplicate with constructRenderables
           // pool.updateUniform

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -441,10 +441,16 @@ EM.addEagerInit([RenderableConstructDef], [RendererDef], [], () => {
 //     never(kind);
 //   }
 // }
+interface RiggedRenderable {
+  meshHandle: RiggedMeshHandle;
+  rigging: Rigging;
+  jointMatrices: mat4[];
+}
 
-export const RiggedRenderableDef = EM.defineComponent(
+export const RiggedRenderableDef = EM.defineComponent2(
   "riggedRenderable",
-  (meshHandle: RiggedMeshHandle, rigging: Rigging) => ({
+  () => ({} as unknown as RiggedRenderable), // TODO(@darzu): HACK. Need NonupdatableComponentDef
+  (p, meshHandle: RiggedMeshHandle, rigging: Rigging) => ({
     meshHandle,
     rigging,
     jointMatrices: rigging.parents.map(() => mat4.identity(mat4.create())),

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -8,6 +8,7 @@ import {
   updateFrameFromTransform,
   updateFrameFromPosRotScale,
   copyFrame,
+  createFrame,
 } from "../physics/transform.js";
 import {
   MotionSmoothingDef,
@@ -19,7 +20,7 @@ import { meshPoolPtr } from "./pipelines/std-scene.js";
 import { CanvasDef } from "./canvas.js";
 import { createRenderer } from "./renderer-webgpu.js";
 import { CyMeshPoolPtr, CyPipelinePtr } from "./gpu-registry.js";
-import { createFrame, WorldFrameDef } from "../physics/nonintersection.js";
+import { WorldFrameDef } from "../physics/nonintersection.js";
 import { tempVec3 } from "../matrix/temp-pool.js";
 import { isMeshHandle, MeshHandle, MeshReserve } from "./mesh-pool.js";
 import { isRigged, Mesh, RiggedMesh, Rigging } from "../meshes/mesh.js";

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -209,7 +209,7 @@ EM.addEagerInit([RenderableConstructDef], [RendererDef], [], () => {
 
           // pool.updateUniform
           const uni = pool.ptr.computeUniData(mesh);
-          EM.ensureComponentOn(e, pool.ptr.dataDef, uni);
+          EM.set(e, pool.ptr.dataDef, uni);
           // TODO(@darzu): HACK! We need some notion of required uni data maybe? Or common uni data
           if ("id" in e[pool.ptr.dataDef.name]) {
             // console.log(
@@ -458,7 +458,7 @@ EM.addEagerInit([RiggedRenderableConstructDef], [RendererDef], [], (res) => {
           // TODO(@darzu): de-duplicate with constructRenderables
           // pool.updateUniform
           const uni = pool.ptr.computeUniData(mesh);
-          EM.ensureComponentOn(e, pool.ptr.dataDef, uni);
+          EM.set(e, pool.ptr.dataDef, uni);
           // TODO(@darzu): HACK! We need some notion of required uni data maybe? Or common uni data
           if ("id" in e[pool.ptr.dataDef.name]) {
             // console.log(

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -207,8 +207,7 @@ EM.addEagerInit([RenderableConstructDef], [RendererDef], [], () => {
           });
 
           // pool.updateUniform
-          const uni = pool.ptr.computeUniData(mesh);
-          EM.ensureComponentOn(e, pool.ptr.dataDef, uni);
+          EM.ensureComponentOn(e, pool.ptr.dataDef, mesh);
           // TODO(@darzu): HACK! We need some notion of required uni data maybe? Or common uni data
           if ("id" in e[pool.ptr.dataDef.name]) {
             // console.log(
@@ -454,9 +453,9 @@ EM.addEagerInit([RiggedRenderableConstructDef], [RendererDef], [], (res) => {
 
           EM.addComponent(e.id, RiggedRenderableDef, meshHandle, mesh.rigging);
 
+          // TODO(@darzu): de-duplicate with constructRenderables
           // pool.updateUniform
-          const uni = pool.ptr.computeUniData(mesh);
-          EM.ensureComponentOn(e, pool.ptr.dataDef, uni);
+          EM.ensureComponentOn(e, pool.ptr.dataDef, mesh);
           // TODO(@darzu): HACK! We need some notion of required uni data maybe? Or common uni data
           if ("id" in e[pool.ptr.dataDef.name]) {
             // console.log(

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -118,12 +118,18 @@ export const RenderableConstructDef = EM.defineComponent2(
   }
 );
 
-export const RiggedRenderableConstructDef = EM.defineComponent(
+export const RiggedRenderableConstructDef = EM.defineComponent2(
   "riggedRenderableConstruct",
   // TODO: consider including other RenderableConstruct fields here
-  (mesh: RiggedMesh) => ({
-    mesh,
-  })
+  () => ({
+    // TODO(@darzu): Wish we didn't have to do this hack here. We need a "NonsyncableComponentDef" that is allowed
+    //    to take constructor arguments. See comment on ComponentDef
+    mesh: undefined as any as RiggedMesh,
+  }),
+  (p, mesh: RiggedMesh) => {
+    p.mesh = mesh;
+    return p;
+  }
 );
 
 export interface Renderable {
@@ -134,9 +140,11 @@ export interface Renderable {
   meshHandle: MeshHandle;
 }
 
-export const RenderableDef = EM.defineComponent(
+export const RenderableDef = EM.defineComponent2(
   "renderable",
-  (r: Renderable) => r
+  // TODO(@darzu): HACK. Need NonsyncableComponentDef
+  () => undefined as any as Renderable,
+  (p, r: Renderable) => r
 );
 
 // TODO: standardize names more
@@ -146,9 +154,10 @@ export const RenderableDef = EM.defineComponent(
 //   (r: MeshUniformTS) => r
 // );
 
-export const RendererWorldFrameDef = EM.defineComponent(
+export const RendererWorldFrameDef = EM.defineComponent2(
   "rendererWorldFrame",
-  () => createFrame()
+  () => createFrame(),
+  (p) => p
 );
 
 // TODO(@darzu): We need to add constraints for updateRendererWorldFrames and such w/ respect to gameplay, physics, and rendering!

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -80,7 +80,7 @@ interface _RenderableConstruct {
 }
 export type RenderableConstruct = Readonly<_RenderableConstruct>;
 
-export const RenderableConstructDef = EM.defineComponent2(
+export const RenderableConstructDef = EM.defineComponent(
   "renderableConstruct",
   () => {
     const r: RenderableConstruct = {
@@ -118,7 +118,7 @@ export const RenderableConstructDef = EM.defineComponent2(
   }
 );
 
-export const RiggedRenderableConstructDef = EM.defineComponent2(
+export const RiggedRenderableConstructDef = EM.defineComponent(
   "riggedRenderableConstruct",
   // TODO: consider including other RenderableConstruct fields here
   () => ({
@@ -140,7 +140,7 @@ export interface Renderable {
   meshHandle: MeshHandle;
 }
 
-export const RenderableDef = EM.defineComponent2(
+export const RenderableDef = EM.defineComponent(
   "renderable",
   // TODO(@darzu): HACK. Need NonsyncableComponentDef
   () => undefined as any as Renderable,
@@ -154,7 +154,7 @@ export const RenderableDef = EM.defineComponent2(
 //   (r: MeshUniformTS) => r
 // );
 
-export const RendererWorldFrameDef = EM.defineComponent2(
+export const RendererWorldFrameDef = EM.defineComponent(
   "rendererWorldFrame",
   () => createFrame(),
   (p) => p
@@ -447,7 +447,7 @@ interface RiggedRenderable {
   jointMatrices: mat4[];
 }
 
-export const RiggedRenderableDef = EM.defineComponent2(
+export const RiggedRenderableDef = EM.defineComponent(
   "riggedRenderable",
   () => ({} as unknown as RiggedRenderable), // TODO(@darzu): HACK. Need NonupdatableComponentDef
   (p, meshHandle: RiggedMeshHandle, rigging: Rigging) => ({

--- a/src/render/renderer-ecs.ts
+++ b/src/render/renderer-ecs.ts
@@ -61,47 +61,60 @@ export const RendererDef = EM.defineResource(
 // TODO(@darzu): we need a better way to handle arbitrary pools
 // TODO(@darzu): support height map?
 // export type PoolKind = "std" | "ocean" | "grass";
-export interface RenderableConstruct {
-  readonly enabled: boolean;
-  readonly sortLayer: number;
+interface _RenderableConstruct {
+  enabled: boolean;
+  sortLayer: number;
   // TODO(@darzu): mask is inconsitently placed; here it is in the component,
   //  later it is in the mesh handle.
-  readonly mask?: number;
-  readonly pool: CyMeshPoolPtr<any, any>;
+  mask?: number;
+  pool: CyMeshPoolPtr<any, any>;
   // TODO(@darzu): little hacky: hidden vs enabled?
   // NOTE:
   //   "enabled" objects are debundled and not sent to the GPU.
   //   "hidden" objects are sent to the GPU w/ scale 0 (so they don't appear).
   //   hidden objects might be more efficient in object pools b/c it causes
   //   less rebundling, but this needs measurement.
-  readonly hidden: boolean;
+  hidden: boolean;
   meshOrProto: Mesh | MeshHandle;
-  readonly reserve?: MeshReserve;
+  reserve?: MeshReserve;
 }
+export type RenderableConstruct = Readonly<_RenderableConstruct>;
 
-export const RenderableConstructDef = EM.defineComponent(
+export const RenderableConstructDef = EM.defineComponent2(
   "renderableConstruct",
-  (
-    // TODO(@darzu): this constructor is too messy, we should use a params obj instead
-    meshOrProto: Mesh | MeshHandle,
-    enabled: boolean = true,
-    // TODO(@darzu): do we need sort layers? Do we use them?
-    sortLayer: number = 0,
-    mask?: number,
-    pool?: CyMeshPoolPtr<any, any>,
-    hidden: boolean = false,
-    reserve?: MeshReserve
-  ) => {
+  () => {
     const r: RenderableConstruct = {
-      enabled,
-      sortLayer: sortLayer,
-      meshOrProto,
-      mask,
-      pool: pool ?? meshPoolPtr,
-      hidden,
-      reserve,
+      enabled: true,
+      sortLayer: 0,
+      meshOrProto: undefined as any as Mesh | MeshHandle,
+      mask: undefined,
+      pool: meshPoolPtr,
+      hidden: false,
+      reserve: undefined,
     };
     return r;
+  },
+  (
+    p,
+    // TODO(@darzu): this constructor is too messy, we should use a params obj instead
+    meshOrProto: Mesh | MeshHandle,
+    enabled?: boolean,
+    // TODO(@darzu): do we need sort layers? Do we use them?
+    sortLayer?: number,
+    mask?: number,
+    pool?: CyMeshPoolPtr<any, any>,
+    hidden?: boolean,
+    reserve?: MeshReserve
+  ) => {
+    const _p = p as _RenderableConstruct;
+    _p.meshOrProto = meshOrProto;
+    if (enabled !== undefined) _p.enabled = enabled;
+    if (sortLayer !== undefined) _p.sortLayer = sortLayer;
+    if (mask !== undefined) _p.mask = mask;
+    if (pool !== undefined) _p.pool = pool;
+    if (hidden !== undefined) _p.hidden = hidden;
+    if (reserve !== undefined) _p.reserve = reserve;
+    return p;
   }
 );
 

--- a/src/stone/stone.ts
+++ b/src/stone/stone.ts
@@ -338,21 +338,17 @@ export const towerPool = createEntityPool<
     const res = await EM.whenResources(TowerMeshes);
     const tower = EM.new();
     const cannon = EM.new();
-    EM.ensureComponentOn(
-      cannon,
-      RenderableConstructDef,
-      res.towerMeshes.ld53_cannon.proto
-    );
-    EM.ensureComponentOn(cannon, PositionDef);
-    EM.ensureComponentOn(cannon, ColorDef, V(0.05, 0.05, 0.05));
-    EM.ensureComponentOn(cannon, RotationDef);
-    EM.ensureComponentOn(cannon, PhysicsParentDef, tower.id);
-    EM.ensureComponentOn(cannon, WorldFrameDef);
+    EM.set(cannon, RenderableConstructDef, res.towerMeshes.ld53_cannon.proto);
+    EM.set(cannon, PositionDef);
+    EM.set(cannon, ColorDef, V(0.05, 0.05, 0.05));
+    EM.set(cannon, RotationDef);
+    EM.set(cannon, PhysicsParentDef, tower.id);
+    EM.set(cannon, WorldFrameDef);
     vec3.set(baseRadius - 2, height * 0.7, 0, cannon.position);
 
-    EM.ensureComponentOn(tower, StoneTowerDef, cannon);
-    EM.ensureComponentOn(tower, PositionDef);
-    EM.ensureComponentOn(tower, RotationDef);
+    EM.set(tower, StoneTowerDef, cannon);
+    EM.set(tower, PositionDef);
+    EM.set(tower, RotationDef);
     const mesh = tower.stoneTower.mesh;
 
     const rows = Math.floor(height / approxBrickHeight);
@@ -480,13 +476,13 @@ export const towerPool = createEntityPool<
       ),
     };
     knockOutBricks(tower.stoneTower, windowAABB, true);
-    EM.ensureComponentOn(tower, ColliderDef, {
+    EM.set(tower, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: towerAABB,
     });
 
-    EM.ensureComponentOn(tower, RenderableConstructDef, mesh);
+    EM.set(tower, RenderableConstructDef, mesh);
     tower.stoneTower.totalBricks = totalBricks;
     tower.stoneTower.currentBricks = totalBricks;
     return tower;
@@ -519,14 +515,14 @@ export const towerPool = createEntityPool<
     // tower
     if (!DeadDef.isOn(e)) {
       // dead platform
-      EM.ensureComponentOn(e, DeadDef);
+      EM.set(e, DeadDef);
       if (RenderableDef.isOn(e)) e.renderable.hidden = true;
       e.dead.processed = true;
 
       // dead cannon
       if (e.stoneTower.cannon()) {
         const c = e.stoneTower.cannon()!;
-        EM.ensureComponentOn(c, DeadDef);
+        EM.set(c, DeadDef);
         if (RenderableDef.isOn(c)) c.renderable.hidden = true;
         c.dead.processed = true;
       }
@@ -559,25 +555,21 @@ export const flyingBrickPool = createEntityPool<
   create: async () => {
     const res = await EM.whenResources(TowerMeshes);
     const brick = EM.new();
-    EM.ensureComponentOn(brick, FlyingBrickDef);
-    EM.ensureComponentOn(brick, PositionDef);
-    EM.ensureComponentOn(brick, RotationDef);
-    EM.ensureComponentOn(brick, LinearVelocityDef);
-    EM.ensureComponentOn(brick, AngularVelocityDef);
-    EM.ensureComponentOn(brick, ColorDef);
-    EM.ensureComponentOn(brick, LifetimeDef);
-    EM.ensureComponentOn(
-      brick,
-      RenderableConstructDef,
-      res.towerMeshes.cube.proto
-    );
-    EM.ensureComponentOn(brick, GravityDef, V(0, -GRAVITY, 0));
-    EM.ensureComponentOn(
+    EM.set(brick, FlyingBrickDef);
+    EM.set(brick, PositionDef);
+    EM.set(brick, RotationDef);
+    EM.set(brick, LinearVelocityDef);
+    EM.set(brick, AngularVelocityDef);
+    EM.set(brick, ColorDef);
+    EM.set(brick, LifetimeDef);
+    EM.set(brick, RenderableConstructDef, res.towerMeshes.cube.proto);
+    EM.set(brick, GravityDef, V(0, -GRAVITY, 0));
+    EM.set(
       brick,
       ScaleDef,
       V(approxBrickWidth / 2, approxBrickHeight / 2, brickDepth / 2)
     );
-    EM.ensureComponentOn(brick, PhysicsParentDef);
+    EM.set(brick, PhysicsParentDef);
     return brick;
   },
   onSpawn: async (e) => {
@@ -609,7 +601,7 @@ export const flyingBrickPool = createEntityPool<
     e.lifetime.ms = e.lifetime.startMs;
   },
   onDespawn: (e) => {
-    EM.ensureComponentOn(e, DeadDef);
+    EM.set(e, DeadDef);
     if (RenderableDef.isOn(e)) e.renderable.hidden = true;
     e.dead.processed = true;
   },

--- a/src/stone/stone.ts
+++ b/src/stone/stone.ts
@@ -84,7 +84,7 @@ interface Tower {
   alive: boolean;
 }
 
-export const StoneTowerDef = EM.defineComponent(
+export const StoneTowerDef = EM.defineNonupdatableComponent(
   "stoneTower",
   (
     cannon: EntityW<
@@ -538,7 +538,10 @@ export async function spawnStoneTower() {
   return towerPool.spawn();
 }
 
-export const FlyingBrickDef = EM.defineComponent("flyingBrick", () => true);
+export const FlyingBrickDef = EM.defineNonupdatableComponent(
+  "flyingBrick",
+  () => true
+);
 
 const maxFlyingBricks = 50;
 

--- a/src/stone/stone.ts
+++ b/src/stone/stone.ts
@@ -538,10 +538,7 @@ export async function spawnStoneTower() {
   return towerPool.spawn();
 }
 
-export const FlyingBrickDef = EM.defineNonupdatableComponent(
-  "flyingBrick",
-  () => true
-);
+export const FlyingBrickDef = EM.defineComponent("flyingBrick", () => true);
 
 const maxFlyingBricks = 50;
 

--- a/src/turret/turret.ts
+++ b/src/turret/turret.ts
@@ -63,10 +63,10 @@ export function constructNetTurret(
     typeof RotationDef
   ]
 > {
-  EM.ensureComponentOn(e, YawPitchDef);
+  EM.set(e, YawPitchDef);
   e.yawpitch.yaw = startYaw;
   e.yawpitch.pitch = startPitch;
-  EM.ensureComponentOn(e, TurretDef);
+  EM.set(e, TurretDef);
   e.turret.minYaw = startYaw - yawRange / 2;
   e.turret.maxYaw = startYaw + yawRange / 2;
   e.turret.cameraYawOffset = cameraYawOffset;
@@ -76,12 +76,12 @@ export function constructNetTurret(
   e.turret.keyboardSpeed = keyboardSpeed;
   e.turret.helpText = helpText;
 
-  EM.ensureComponentOn(e, RotationDef);
-  EM.ensureComponentOn(e, SyncDef);
+  EM.set(e, RotationDef);
+  EM.set(e, SyncDef);
   e.sync.dynamicComponents.push(YawPitchDef.id);
 
   // setup camera params
-  EM.ensureComponentOn(e, CameraFollowDef, 0);
+  EM.set(e, CameraFollowDef, 0);
   vec3.copy(e.cameraFollow.positionOffset, cameraFollowOffset);
   e.cameraFollow.yawOffset = cameraYawOffset;
   e.cameraFollow.pitchOffset = cameraPitchOffset;
@@ -93,9 +93,9 @@ export function constructNetTurret(
     const interactAABB = copyAABB(createAABB(), aabbOrInteractionEntity);
     vec3.scale(interactAABB.min, 2, interactAABB.min);
     vec3.scale(interactAABB.max, 2, interactAABB.max);
-    EM.ensureComponentOn(interactBox, PhysicsParentDef, e.id);
-    EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, 0));
-    EM.ensureComponentOn(interactBox, ColliderDef, {
+    EM.set(interactBox, PhysicsParentDef, e.id);
+    EM.set(interactBox, PositionDef, V(0, 0, 0));
+    EM.set(interactBox, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: interactAABB,
@@ -103,7 +103,7 @@ export function constructNetTurret(
   } else {
     interactBox = aabbOrInteractionEntity;
   }
-  EM.ensureComponentOn(e, InteractableDef);
+  EM.set(e, InteractableDef);
   e.interaction.colliderId = interactBox.id;
 }
 

--- a/src/turret/turret.ts
+++ b/src/turret/turret.ts
@@ -24,7 +24,7 @@ import { YawPitchDef, yawpitchToQuat } from "./yawpitch.js";
 import { TextDef } from "../gui/ui.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const TurretDef = EM.defineComponent("turret", () => {
+export const TurretDef = EM.defineNonupdatableComponent("turret", () => {
   return {
     mannedId: 0,
     minYaw: -Math.PI * 0.5,

--- a/src/turret/turret.ts
+++ b/src/turret/turret.ts
@@ -24,7 +24,7 @@ import { YawPitchDef, yawpitchToQuat } from "./yawpitch.js";
 import { TextDef } from "../gui/ui.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const TurretDef = EM.defineNonupdatableComponent("turret", () => {
+export const TurretDef = EM.defineComponent("turret", () => {
   return {
     mannedId: 0,
     minYaw: -Math.PI * 0.5,

--- a/src/turret/yawpitch.ts
+++ b/src/turret/yawpitch.ts
@@ -11,8 +11,8 @@ export const YawPitchDef = defineSerializableComponent(
     };
   },
   (p, yaw?: number, pitch?: number) => {
-    if (yaw) p.yaw = yaw;
-    if (pitch) p.pitch = pitch;
+    if (yaw !== undefined) p.yaw = yaw;
+    if (pitch !== undefined) p.pitch = pitch;
     return p;
   },
   (o, buf) => {

--- a/src/turret/yawpitch.ts
+++ b/src/turret/yawpitch.ts
@@ -4,11 +4,16 @@ import { vec2, vec3, vec4, quat, mat4, V } from "../matrix/sprig-matrix.js";
 
 export const YawPitchDef = defineSerializableComponent(
   "yawpitch",
-  (yaw?: number, pitch?: number) => {
+  () => {
     return {
-      yaw: yaw ?? 0,
-      pitch: pitch ?? 0,
+      yaw: 0,
+      pitch: 0,
     };
+  },
+  (p, yaw?: number, pitch?: number) => {
+    if (yaw) p.yaw = yaw;
+    if (pitch) p.pitch = pitch;
+    return p;
   },
   (o, buf) => {
     buf.writeFloat32(o.yaw);

--- a/src/utils/utils-3d.ts
+++ b/src/utils/utils-3d.ts
@@ -67,7 +67,7 @@ export function getPositionFromTransform(t: mat4): vec3 {
   return pos;
 }
 // vec utilities
-export function vec3Floor(out: vec3, v: vec3): vec3 {
+export function vec3Floor(out: vec3, v: vec3.InputT): vec3 {
   out[0] = Math.floor(v[0]);
   out[1] = Math.floor(v[1]);
   out[2] = Math.floor(v[2]);
@@ -77,15 +77,15 @@ export function vec3Floor(out: vec3, v: vec3): vec3 {
 export function aabbDbg(v: AABB): string {
   return `min:${vec3Dbg(v.min)},max:${vec3Dbg(v.max)}`;
 }
-export function vec2Dbg(v: vec2): string {
+export function vec2Dbg(v: vec2.InputT): string {
   return `[${v[0].toFixed(2)},${v[1].toFixed(2)}]`;
 }
-export function vec3Dbg(v?: vec3): string {
+export function vec3Dbg(v?: vec3.InputT): string {
   return v
     ? `[${v[0].toFixed(2)},${v[1].toFixed(2)},${v[2].toFixed(2)}]`
     : "NIL";
 }
-export function vec3Dbg2(v: vec3, precision = 2): string {
+export function vec3Dbg2(v: vec3.InputT, precision = 2): string {
   return `V(${v[0].toFixed(precision)},${v[1].toFixed(
     precision
   )},${v[2].toFixed(precision)})`;

--- a/src/utils/utils-game.ts
+++ b/src/utils/utils-game.ts
@@ -75,7 +75,7 @@ export function createLine(start: vec3, end: vec3, color: vec3) {
   const pos = [start, start2, end2, end];
 
   const e = EM.new();
-  EM.ensureComponentOn(e, ColorDef, color);
+  EM.set(e, ColorDef, color);
   const m: Mesh = {
     pos,
     tri: [],
@@ -87,8 +87,8 @@ export function createLine(start: vec3, end: vec3, color: vec3) {
     surfaceIds: [1, 2],
     usesProvoking: true,
   };
-  EM.ensureComponentOn(e, RenderableConstructDef, m);
-  EM.ensureComponentOn(e, PositionDef);
+  EM.set(e, RenderableConstructDef, m);
+  EM.set(e, PositionDef);
 
   return e;
 }
@@ -101,17 +101,17 @@ const _ballPool = createEntityPool<
   create: async () => {
     let res = await EM.whenResources(AllMeshesDef);
     const e = EM.new();
-    EM.ensureComponentOn(e, ColorDef);
-    EM.ensureComponentOn(e, RenderableConstructDef, res.allMeshes.ball.proto);
-    EM.ensureComponentOn(e, PositionDef);
-    EM.ensureComponentOn(e, ScaleDef);
+    EM.set(e, ColorDef);
+    EM.set(e, RenderableConstructDef, res.allMeshes.ball.proto);
+    EM.set(e, PositionDef);
+    EM.set(e, ScaleDef);
     return e;
   },
   onSpawn: async (e) => {
     EM.tryRemoveComponent(e.id, DeadDef);
   },
   onDespawn: (e) => {
-    EM.ensureComponentOn(e, DeadDef);
+    EM.set(e, DeadDef);
     e.dead.processed = true;
   },
 });
@@ -188,9 +188,9 @@ export async function addGizmoChild(
   // make debug gizmo
   const gizmoMesh = await GizmoMesh.gameMesh();
   const gizmo = EM.new();
-  EM.ensureComponentOn(gizmo, PositionDef, vec3.clone(offset));
-  EM.ensureComponentOn(gizmo, ScaleDef, V(scale, scale, scale));
-  EM.ensureComponentOn(gizmo, PhysicsParentDef, parent.id);
-  EM.ensureComponentOn(gizmo, RenderableConstructDef, gizmoMesh.proto);
+  EM.set(gizmo, PositionDef, vec3.clone(offset));
+  EM.set(gizmo, ScaleDef, V(scale, scale, scale));
+  EM.set(gizmo, PhysicsParentDef, parent.id);
+  EM.set(gizmo, RenderableConstructDef, gizmoMesh.proto);
   return gizmo;
 }

--- a/src/wind/sail.ts
+++ b/src/wind/sail.ts
@@ -34,7 +34,7 @@ const SAIL_TURN_SPEED = 5;
 export const SAIL_FURL_RATE = 0.02;
 const BILLOW_FACTOR = 0.2;
 
-export const SailDef = EM.defineNonupdatableComponent("sail", () => ({
+export const SailDef = EM.defineComponent("sail", () => ({
   width: 1,
   height: 1,
   unfurledAmount: 0.1,
@@ -192,7 +192,7 @@ EM.addSystem(
 
 // EM.addConstraint(["billow", "after", "applyWindToSail"]);
 
-export const MastDef = EM.defineNonupdatableComponent("mast", () => ({
+export const MastDef = EM.defineComponent("mast", () => ({
   sail: createRef(0, [SailDef]),
   force: 0.0,
 }));

--- a/src/wind/sail.ts
+++ b/src/wind/sail.ts
@@ -110,16 +110,16 @@ export function createSail(
   [typeof SailDef, typeof PositionDef, typeof RotationDef, typeof ScaleDef]
 > {
   const ent = EM.new();
-  EM.ensureComponentOn(ent, SailDef);
+  EM.set(ent, SailDef);
   ent.sail.width = width;
   ent.sail.height = height;
   const mesh = sailMesh(ent.sail);
-  EM.ensureComponentOn(ent, RenderableConstructDef, mesh);
-  EM.ensureComponentOn(ent, ScaleDef, V(scale, scale, scale));
-  EM.ensureComponentOn(ent, PositionDef);
-  EM.ensureComponentOn(ent, RotationDef);
+  EM.set(ent, RenderableConstructDef, mesh);
+  EM.set(ent, ScaleDef, V(scale, scale, scale));
+  EM.set(ent, PositionDef);
+  EM.set(ent, RotationDef);
   // EM.ensureComponentOn(ent, ColorDef, V(0.9, 0.9, 0.9));
-  EM.ensureComponentOn(ent, ColorDef, ENDESGA16.red);
+  EM.set(ent, ColorDef, ENDESGA16.red);
   return ent;
 }
 
@@ -201,18 +201,18 @@ export async function createMast() {
   const res = await EM.whenResources(MeDef);
   const mesh = await MastMesh.gameMesh();
   let ent = EM.new();
-  EM.ensureComponentOn(ent, MastDef);
-  EM.ensureComponentOn(ent, RenderableConstructDef, mesh.proto);
-  EM.ensureComponentOn(ent, ColliderDef, {
+  EM.set(ent, MastDef);
+  EM.set(ent, RenderableConstructDef, mesh.proto);
+  EM.set(ent, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: mesh.aabb,
   });
-  EM.ensureComponentOn(ent, PositionDef);
-  EM.ensureComponentOn(ent, RotationDef);
+  EM.set(ent, PositionDef);
+  EM.set(ent, RotationDef);
   // EM.ensureComponentOn(ent, ColorDef, V(0.8, 0.7, 0.3));
-  EM.ensureComponentOn(ent, ColorDef, ENDESGA16.darkBrown);
-  EM.ensureComponentOn(ent, AuthorityDef, res.me.pid);
+  EM.set(ent, ColorDef, ENDESGA16.darkBrown);
+  EM.set(ent, AuthorityDef, res.me.pid);
 
   // EM.set(ent, YawPitchDef);
 
@@ -251,7 +251,7 @@ export async function createMast() {
 
   const sailWidth = 14;
   const sail = createSail(sailWidth, 8, 2);
-  EM.ensureComponentOn(sail, PhysicsParentDef, ent.id);
+  EM.set(sail, PhysicsParentDef, ent.id);
   sail.position[0] = -sailWidth;
   sail.position[1] = 38;
   sail.position[2] = 0.51;

--- a/src/wind/sail.ts
+++ b/src/wind/sail.ts
@@ -34,7 +34,7 @@ const SAIL_TURN_SPEED = 5;
 export const SAIL_FURL_RATE = 0.02;
 const BILLOW_FACTOR = 0.2;
 
-export const SailDef = EM.defineComponent("sail", () => ({
+export const SailDef = EM.defineNonupdatableComponent("sail", () => ({
   width: 1,
   height: 1,
   unfurledAmount: 0.1,
@@ -192,7 +192,7 @@ EM.addSystem(
 
 // EM.addConstraint(["billow", "after", "applyWindToSail"]);
 
-export const MastDef = EM.defineComponent("mast", () => ({
+export const MastDef = EM.defineNonupdatableComponent("mast", () => ({
   sail: createRef(0, [SailDef]),
   force: 0.0,
 }));

--- a/src/wind/sail.ts
+++ b/src/wind/sail.ts
@@ -118,7 +118,7 @@ export function createSail(
   EM.set(ent, ScaleDef, V(scale, scale, scale));
   EM.set(ent, PositionDef);
   EM.set(ent, RotationDef);
-  // EM.ensureComponentOn(ent, ColorDef, V(0.9, 0.9, 0.9));
+  // EM.set(ent, ColorDef, V(0.9, 0.9, 0.9));
   EM.set(ent, ColorDef, ENDESGA16.red);
   return ent;
 }
@@ -210,7 +210,7 @@ export async function createMast() {
   });
   EM.set(ent, PositionDef);
   EM.set(ent, RotationDef);
-  // EM.ensureComponentOn(ent, ColorDef, V(0.8, 0.7, 0.3));
+  // EM.set(ent, ColorDef, V(0.8, 0.7, 0.3));
   EM.set(ent, ColorDef, ENDESGA16.darkBrown);
   EM.set(ent, AuthorityDef, res.me.pid);
 

--- a/src/wind/windsock.ts
+++ b/src/wind/windsock.ts
@@ -13,7 +13,7 @@ import { WindDef } from "./wind.js";
 import { assert } from "../utils/util.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const SockDef = EM.defineComponent("sock", () => ({
+export const SockDef = EM.defineNonupdatableComponent("sock", () => ({
   scale: 1,
 }));
 

--- a/src/wind/windsock.ts
+++ b/src/wind/windsock.ts
@@ -37,15 +37,15 @@ function sockMesh(): Mesh {
 
 export function createSock(scale: number) {
   const ent = EM.new();
-  EM.ensureComponentOn(ent, SockDef);
+  EM.set(ent, SockDef);
   ent.sock.scale = scale;
   const mesh = sockMesh();
   // scaleMesh(mesh, scale);
-  EM.ensureComponentOn(ent, ScaleDef, V(scale, scale, scale));
-  EM.ensureComponentOn(ent, RenderableConstructDef, mesh);
-  EM.ensureComponentOn(ent, PositionDef);
-  EM.ensureComponentOn(ent, RotationDef);
-  EM.ensureComponentOn(ent, ColorDef, V(0.9, 0.9, 0.9));
+  EM.set(ent, ScaleDef, V(scale, scale, scale));
+  EM.set(ent, RenderableConstructDef, mesh);
+  EM.set(ent, PositionDef);
+  EM.set(ent, RotationDef);
+  EM.set(ent, ColorDef, V(0.9, 0.9, 0.9));
   return ent;
 }
 

--- a/src/wind/windsock.ts
+++ b/src/wind/windsock.ts
@@ -13,7 +13,7 @@ import { WindDef } from "./wind.js";
 import { assert } from "../utils/util.js";
 import { Phase } from "../ecs/sys-phase.js";
 
-export const SockDef = EM.defineNonupdatableComponent("sock", () => ({
+export const SockDef = EM.defineComponent("sock", () => ({
   scale: 1,
 }));
 

--- a/src/wood/game-shipyard.ts
+++ b/src/wood/game-shipyard.ts
@@ -196,25 +196,25 @@ export async function initShipyardGame(hosting: boolean) {
   );
   EM.set(ground, RenderableConstructDef, groundMesh);
   EM.set(ground, ColorDef, ENDESGA16.blue);
-  // EM.ensureComponentOn(p, ColorDef, [0.2, 0.3, 0.2]);
+  // EM.set(p, ColorDef, [0.2, 0.3, 0.2]);
   EM.set(ground, PositionDef, V(0, 0, 0));
-  // EM.ensureComponentOn(plane, PositionDef, [0, -5, 0]);
+  // EM.set(plane, PositionDef, [0, -5, 0]);
 
   // const cube = EM.newEntity();
   // const cubeMesh = cloneMesh(res.allMeshes.cube.mesh);
-  // EM.ensureComponentOn(cube, RenderableConstructDef, cubeMesh);
-  // EM.ensureComponentOn(cube, ColorDef, [0.1, 0.1, 0.1]);
-  // EM.ensureComponentOn(cube, PositionDef, [0, 0, 3]);
-  // EM.ensureComponentOn(cube, RotationDef);
-  // EM.ensureComponentOn(cube, AngularVelocityDef, [0, 0.001, 0.001]);
-  // EM.ensureComponentOn(cube, WorldFrameDef);
-  // EM.ensureComponentOn(cube, ColliderDef, {
+  // EM.set(cube, RenderableConstructDef, cubeMesh);
+  // EM.set(cube, ColorDef, [0.1, 0.1, 0.1]);
+  // EM.set(cube, PositionDef, [0, 0, 3]);
+  // EM.set(cube, RotationDef);
+  // EM.set(cube, AngularVelocityDef, [0, 0.001, 0.001]);
+  // EM.set(cube, WorldFrameDef);
+  // EM.set(cube, ColliderDef, {
   //   shape: "AABB",
   //   solid: false,
   //   aabb: res.allMeshes.cube.aabb,
   // });
 
-  // EM.ensureComponentOn(b1, ColliderDef, {
+  // EM.set(b1, ColliderDef, {
   //   shape: "Box",
   //   solid: false,
   //   center: res.allMeshes.cube.center,
@@ -224,20 +224,20 @@ export async function initShipyardGame(hosting: boolean) {
   // TODO(@darzu): timber system here!
   // const sphereMesh = cloneMesh(res.allMeshes.ball.mesh);
   // const visible = false;
-  // EM.ensureComponentOn(_player, RenderableConstructDef, sphereMesh, visible);
-  // EM.ensureComponentOn(_player, ColorDef, [0.1, 0.1, 0.1]);
-  // EM.ensureComponentOn(_player, PositionDef, [0, 0, 0]);
-  // // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-  // EM.ensureComponentOn(_player, WorldFrameDef);
-  // // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-  // EM.ensureComponentOn(_player, ColliderDef, {
+  // EM.set(_player, RenderableConstructDef, sphereMesh, visible);
+  // EM.set(_player, ColorDef, [0.1, 0.1, 0.1]);
+  // EM.set(_player, PositionDef, [0, 0, 0]);
+  // // EM.set(b2, PositionDef, [0, 0, -1.2]);
+  // EM.set(_player, WorldFrameDef);
+  // // EM.set(b2, PhysicsParentDef, g.id);
+  // EM.set(_player, ColliderDef, {
   //   shape: "AABB",
   //   solid: false,
   //   aabb: res.allMeshes.ball.aabb,
   // });
   // randomizeMeshColors(b2);
 
-  // EM.ensureComponentOn(b2, ColliderDef, {
+  // EM.set(b2, ColliderDef, {
   //   shape: "Box",
   //   solid: false,
   //   center: res.allMeshes.cube.center,
@@ -273,7 +273,7 @@ export async function initShipyardGame(hosting: boolean) {
   EM.set(timber, RenderableConstructDef, timberMesh);
   EM.set(timber, WoodStateDef, timberState);
   EM.set(timber, ColorDef, ENDESGA16.darkBrown);
-  // EM.ensureComponentOn(timber, ColorDef, [0.1, 0.1, 0.1]);
+  // EM.set(timber, ColorDef, [0.1, 0.1, 0.1]);
   // const scale = 1 * Math.pow(0.8, ti);
   const scale = 1;
   const timberAABB = getAABBFromMesh(timberMesh);
@@ -287,7 +287,7 @@ export async function initShipyardGame(hosting: boolean) {
   // timberPos[0] -= ribCount * 0.5 * ribSpace;
   // timberPos[2] -= floorPlankCount * 0.5 * floorSpace;
   EM.set(timber, PositionDef, timberPos);
-  // EM.ensureComponentOn(timber, PositionDef, [0, 0, -4]);
+  // EM.set(timber, PositionDef, [0, 0, -4]);
   EM.set(timber, RotationDef);
   EM.set(timber, ScaleDef, V(scale, scale, scale));
   EM.set(timber, WorldFrameDef);
@@ -307,22 +307,22 @@ export async function initShipyardGame(hosting: boolean) {
   // for (let i = 0; i < 2; i++) {
   //   const isLeft = i === 0 ? 1 : -1;
   //   const cannon = EM.new();
-  //   EM.ensureComponentOn(
+  //   EM.set(
   //     cannon,
   //     RenderableConstructDef,
   //     res.allMeshes.ld51_cannon.proto
   //   );
-  //   EM.ensureComponentOn(
+  //   EM.set(
   //     cannon,
   //     PositionDef,
   //     V(-7.5, realFloorHeight + 2, -4 * isLeft)
   //   );
-  //   EM.ensureComponentOn(cannon, RotationDef);
+  //   EM.set(cannon, RotationDef);
   //   quat.rotateX(cannon.rotation, Math.PI * 0.01 * isLeft, cannon.rotation);
   //   if (isLeft !== 1) {
   //     quat.rotateY(cannon.rotation, Math.PI, cannon.rotation);
   //   }
-  //   EM.ensureComponentOn(cannon, ColorDef, ENDESGA16.darkGreen);
+  //   EM.set(cannon, ColorDef, ENDESGA16.darkGreen);
   //   // TODO(@darzu): USE PALETTE PROPERLY
   //   // TODO(@darzu): USE PALETTE PROPERLY
   //   vec3.scale(cannon.color, 0.5, cannon.color);
@@ -331,16 +331,16 @@ export async function initShipyardGame(hosting: boolean) {
   //     const interactAABB = copyAABB(createAABB(), res.allMeshes.ld51_cannon.aabb);
   //     vec3.scale(interactAABB.min, 2, interactAABB.min);
   //     vec3.scale(interactAABB.max, 2, interactAABB.max);
-  //     EM.ensureComponentOn(interactBox, PhysicsParentDef, cannon.id);
-  //     EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, 0));
-  //     EM.ensureComponentOn(interactBox, ColliderDef, {
+  //     EM.set(interactBox, PhysicsParentDef, cannon.id);
+  //     EM.set(interactBox, PositionDef, V(0, 0, 0));
+  //     EM.set(interactBox, ColliderDef, {
   //       shape: "AABB",
   //       solid: false,
   //       aabb: interactAABB,
   //     });
-  //     EM.ensureComponentOn(cannon, InteractableDef, interactBox.id);
+  //     EM.set(cannon, InteractableDef, interactBox.id);
   //   }
-  //   EM.ensureComponentOn(cannon, LD51CannonDef);
+  //   EM.set(cannon, LD51CannonDef);
   // }
 
   // TODO(@darzu): use a pool for goodballs
@@ -391,7 +391,7 @@ export async function initShipyardGame(hosting: boolean) {
         aabb: interactAABB,
       });
       EM.set(newBall, InteractableDef, interactBox.id);
-      // EM.ensureComponentOn(ball, WorldFrameDef);
+      // EM.set(ball, WorldFrameDef);
       EM.set(newBall, GoodBallDef, idx, interactBox.id);
 
       ball = newBall;
@@ -729,7 +729,7 @@ export async function initShipyardGame(hosting: boolean) {
                     // vec3.zero(b.linearVelocity);
                     // vec3.zero(b.gravity);
                     if (_goodBallPool.numFree() > 0) {
-                      // EM.ensureComponentOn(b, DeletedDef);
+                      // EM.set(b, DeletedDef);
                       EM.set(b, DeadDef);
                       spawnGoodBall(b.world.position);
                     } else {
@@ -833,9 +833,9 @@ export async function initShipyardGame(hosting: boolean) {
       EM.set(g, RenderableConstructDef, sphereMesh, visible);
       EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
       EM.set(g, PositionDef, V(0, 0, 0));
-      // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
+      // EM.set(b2, PositionDef, [0, 0, -1.2]);
       EM.set(g, WorldFrameDef);
-      // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
+      // EM.set(b2, PhysicsParentDef, g.id);
       EM.set(g, ColliderDef, {
         shape: "AABB",
         solid: false,

--- a/src/wood/game-shipyard.ts
+++ b/src/wood/game-shipyard.ts
@@ -152,9 +152,12 @@ let healthPercent = 100;
 
 const MAX_GOODBALLS = 10;
 
-export const LD51CannonDef = EM.defineComponent("ld51Cannon", () => {
-  return {};
-});
+export const LD51CannonDef = EM.defineNonupdatableComponent(
+  "ld51Cannon",
+  () => {
+    return {};
+  }
+);
 
 export async function initShipyardGame(hosting: boolean) {
   const res = await EM.whenResources(
@@ -348,7 +351,7 @@ export async function initShipyardGame(hosting: boolean) {
   // }
 
   // TODO(@darzu): use a pool for goodballs
-  const GoodBallDef = EM.defineComponent(
+  const GoodBallDef = EM.defineNonupdatableComponent(
     "goodBall",
     (idx: number, interactBoxId: number) => ({
       idx,
@@ -568,7 +571,7 @@ export async function initShipyardGame(hosting: boolean) {
 
   // Create player
   {
-    const ColWallDef = EM.defineComponent("ColWall", () => ({}));
+    const ColWallDef = EM.defineNonupdatableComponent("ColWall", () => ({}));
 
     // create ship bounds
     // TODO(@darzu): move into shipyard?

--- a/src/wood/game-shipyard.ts
+++ b/src/wood/game-shipyard.ts
@@ -152,12 +152,9 @@ let healthPercent = 100;
 
 const MAX_GOODBALLS = 10;
 
-export const LD51CannonDef = EM.defineNonupdatableComponent(
-  "ld51Cannon",
-  () => {
-    return {};
-  }
-);
+export const LD51CannonDef = EM.defineComponent("ld51Cannon", () => {
+  return {};
+});
 
 export async function initShipyardGame(hosting: boolean) {
   const res = await EM.whenResources(
@@ -571,7 +568,7 @@ export async function initShipyardGame(hosting: boolean) {
 
   // Create player
   {
-    const ColWallDef = EM.defineNonupdatableComponent("ColWall", () => ({}));
+    const ColWallDef = EM.defineComponent("ColWall", () => ({}));
 
     // create ship bounds
     // TODO(@darzu): move into shipyard?

--- a/src/wood/game-shipyard.ts
+++ b/src/wood/game-shipyard.ts
@@ -176,18 +176,14 @@ export async function initShipyardGame(hosting: boolean) {
   ];
 
   const sunlight = EM.new();
-  EM.ensureComponentOn(sunlight, PointLightDef);
+  EM.set(sunlight, PointLightDef);
   // sunlight.pointLight.constant = 1.0;
   sunlight.pointLight.constant = 1.0;
   vec3.copy(sunlight.pointLight.ambient, [0.4, 0.4, 0.4]);
   // vec3.scale(sunlight.pointLight.ambient, sunlight.pointLight.ambient, 0.2);
   vec3.copy(sunlight.pointLight.diffuse, [0.5, 0.5, 0.5]);
-  EM.ensureComponentOn(sunlight, PositionDef, V(50, 100, 10));
-  EM.ensureComponentOn(
-    sunlight,
-    RenderableConstructDef,
-    res.allMeshes.ball.proto
-  );
+  EM.set(sunlight, PositionDef, V(50, 100, 10));
+  EM.set(sunlight, RenderableConstructDef, res.allMeshes.ball.proto);
 
   // const c = res.globalCursor3d.cursor()!;
   // if (RenderableDef.isOn(c)) c.renderable.enabled = false;
@@ -198,10 +194,10 @@ export async function initShipyardGame(hosting: boolean) {
     groundMesh,
     mat4.fromRotationTranslationScale(quat.IDENTITY, [0, -4, 0], [20, 2, 20])
   );
-  EM.ensureComponentOn(ground, RenderableConstructDef, groundMesh);
-  EM.ensureComponentOn(ground, ColorDef, ENDESGA16.blue);
+  EM.set(ground, RenderableConstructDef, groundMesh);
+  EM.set(ground, ColorDef, ENDESGA16.blue);
   // EM.ensureComponentOn(p, ColorDef, [0.2, 0.3, 0.2]);
-  EM.ensureComponentOn(ground, PositionDef, V(0, 0, 0));
+  EM.set(ground, PositionDef, V(0, 0, 0));
   // EM.ensureComponentOn(plane, PositionDef, [0, -5, 0]);
 
   // const cube = EM.newEntity();
@@ -274,9 +270,9 @@ export async function initShipyardGame(hosting: boolean) {
 
   const [timberMesh, timberState] = createBarrelMesh();
 
-  EM.ensureComponentOn(timber, RenderableConstructDef, timberMesh);
-  EM.ensureComponentOn(timber, WoodStateDef, timberState);
-  EM.ensureComponentOn(timber, ColorDef, ENDESGA16.darkBrown);
+  EM.set(timber, RenderableConstructDef, timberMesh);
+  EM.set(timber, WoodStateDef, timberState);
+  EM.set(timber, ColorDef, ENDESGA16.darkBrown);
   // EM.ensureComponentOn(timber, ColorDef, [0.1, 0.1, 0.1]);
   // const scale = 1 * Math.pow(0.8, ti);
   const scale = 1;
@@ -290,18 +286,18 @@ export async function initShipyardGame(hosting: boolean) {
   // timberPos[1] += 1;
   // timberPos[0] -= ribCount * 0.5 * ribSpace;
   // timberPos[2] -= floorPlankCount * 0.5 * floorSpace;
-  EM.ensureComponentOn(timber, PositionDef, timberPos);
+  EM.set(timber, PositionDef, timberPos);
   // EM.ensureComponentOn(timber, PositionDef, [0, 0, -4]);
-  EM.ensureComponentOn(timber, RotationDef);
-  EM.ensureComponentOn(timber, ScaleDef, V(scale, scale, scale));
-  EM.ensureComponentOn(timber, WorldFrameDef);
-  EM.ensureComponentOn(timber, ColliderDef, {
+  EM.set(timber, RotationDef);
+  EM.set(timber, ScaleDef, V(scale, scale, scale));
+  EM.set(timber, WorldFrameDef);
+  EM.set(timber, ColliderDef, {
     shape: "AABB",
     solid: false,
     aabb: timberAABB,
   });
   const timberHealth = createWoodHealth(timberState);
-  EM.ensureComponentOn(timber, WoodHealthDef, timberHealth);
+  EM.set(timber, WoodHealthDef, timberHealth);
 
   addGizmoChild(timber, 10);
 
@@ -365,7 +361,7 @@ export async function initShipyardGame(hosting: boolean) {
   >[] = [];
   const _goodBallPool = createIdxPool(MAX_GOODBALLS);
   function despawnGoodBall(e: EntityW<[typeof GoodBallDef]>) {
-    EM.ensureComponentOn(e, DeadDef);
+    EM.set(e, DeadDef);
     if (RenderableDef.isOn(e)) e.renderable.hidden = true;
     _goodBallPool.free(e.goodBall.idx);
     e.dead.processed = true;
@@ -378,29 +374,25 @@ export async function initShipyardGame(hosting: boolean) {
 
     if (!ball) {
       const newBall = EM.new();
-      EM.ensureComponentOn(
-        newBall,
-        RenderableConstructDef,
-        res.allMeshes.ball.proto
-      );
-      EM.ensureComponentOn(newBall, ColorDef, ENDESGA16.orange);
-      EM.ensureComponentOn(newBall, PositionDef);
-      EM.ensureComponentOn(newBall, LinearVelocityDef);
-      EM.ensureComponentOn(newBall, GravityDef);
+      EM.set(newBall, RenderableConstructDef, res.allMeshes.ball.proto);
+      EM.set(newBall, ColorDef, ENDESGA16.orange);
+      EM.set(newBall, PositionDef);
+      EM.set(newBall, LinearVelocityDef);
+      EM.set(newBall, GravityDef);
       const interactBox = EM.new();
       const interactAABB = copyAABB(createAABB(), res.allMeshes.ball.aabb);
       vec3.scale(interactAABB.min, 2, interactAABB.min);
       vec3.scale(interactAABB.max, 2, interactAABB.max);
-      EM.ensureComponentOn(interactBox, PhysicsParentDef, newBall.id);
-      EM.ensureComponentOn(interactBox, PositionDef, V(0, 0, 0));
-      EM.ensureComponentOn(interactBox, ColliderDef, {
+      EM.set(interactBox, PhysicsParentDef, newBall.id);
+      EM.set(interactBox, PositionDef, V(0, 0, 0));
+      EM.set(interactBox, ColliderDef, {
         shape: "AABB",
         solid: false,
         aabb: interactAABB,
       });
-      EM.ensureComponentOn(newBall, InteractableDef, interactBox.id);
+      EM.set(newBall, InteractableDef, interactBox.id);
       // EM.ensureComponentOn(ball, WorldFrameDef);
-      EM.ensureComponentOn(newBall, GoodBallDef, idx, interactBox.id);
+      EM.set(newBall, GoodBallDef, idx, interactBox.id);
 
       ball = newBall;
       _goodBalls[idx] = newBall;
@@ -408,7 +400,7 @@ export async function initShipyardGame(hosting: boolean) {
       if (RenderableDef.isOn(ball)) ball.renderable.hidden = false;
       EM.tryRemoveComponent(ball.id, DeadDef);
       EM.tryRemoveComponent(ball.id, PhysicsParentDef);
-      EM.ensureComponentOn(ball, InteractableDef, ball.goodBall.interactBoxId);
+      EM.set(ball, InteractableDef, ball.goodBall.interactBoxId);
     }
 
     vec3.copy(ball.position, pos);
@@ -586,16 +578,16 @@ export async function initShipyardGame(hosting: boolean) {
         +floorWidth * 0.5,
       ]),
     };
-    EM.ensureComponentOn(colFloor, ColliderDef, {
+    EM.set(colFloor, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: flAABB,
     });
-    EM.ensureComponentOn(colFloor, PositionDef);
-    EM.ensureComponentOn(colFloor, ColWallDef);
+    EM.set(colFloor, PositionDef);
+    EM.set(colFloor, ColWallDef);
 
     const colLeftWall = EM.new();
-    EM.ensureComponentOn(colLeftWall, ColliderDef, {
+    EM.set(colLeftWall, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: {
@@ -607,11 +599,11 @@ export async function initShipyardGame(hosting: boolean) {
         max: V(flAABB.max[0], realCeilHeight, flAABB.min[2]),
       },
     });
-    EM.ensureComponentOn(colLeftWall, PositionDef);
-    EM.ensureComponentOn(colLeftWall, ColWallDef);
+    EM.set(colLeftWall, PositionDef);
+    EM.set(colLeftWall, ColWallDef);
 
     const colRightWall = EM.new();
-    EM.ensureComponentOn(colRightWall, ColliderDef, {
+    EM.set(colRightWall, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: {
@@ -619,11 +611,11 @@ export async function initShipyardGame(hosting: boolean) {
         max: V(flAABB.max[0], realCeilHeight, flAABB.max[2] + 2),
       },
     });
-    EM.ensureComponentOn(colRightWall, PositionDef);
-    EM.ensureComponentOn(colRightWall, ColWallDef);
+    EM.set(colRightWall, PositionDef);
+    EM.set(colRightWall, ColWallDef);
 
     const colFrontWall = EM.new();
-    EM.ensureComponentOn(colFrontWall, ColliderDef, {
+    EM.set(colFrontWall, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: {
@@ -639,11 +631,11 @@ export async function initShipyardGame(hosting: boolean) {
         ]),
       },
     });
-    EM.ensureComponentOn(colFrontWall, PositionDef);
-    EM.ensureComponentOn(colFrontWall, ColWallDef);
+    EM.set(colFrontWall, PositionDef);
+    EM.set(colFrontWall, ColWallDef);
 
     const colBackWall = EM.new();
-    EM.ensureComponentOn(colBackWall, ColliderDef, {
+    EM.set(colBackWall, ColliderDef, {
       shape: "AABB",
       solid: true,
       aabb: {
@@ -655,8 +647,8 @@ export async function initShipyardGame(hosting: boolean) {
         max: V(flAABB.min[0], realCeilHeight, flAABB.max[2] - 0.5),
       },
     });
-    EM.ensureComponentOn(colBackWall, PositionDef);
-    EM.ensureComponentOn(colBackWall, ColWallDef);
+    EM.set(colBackWall, PositionDef);
+    EM.set(colBackWall, ColWallDef);
 
     // debugVizAABB(colFloor);
     // debugVizAABB(colLeftWall);
@@ -672,8 +664,8 @@ export async function initShipyardGame(hosting: boolean) {
       const center = aabbCenter(tempVec3(), aabbEnt.collider.aabb);
       scaleMesh3(mesh, size);
       transformMesh(mesh, mat4.fromTranslation(center));
-      EM.ensureComponentOn(aabbEnt, RenderableConstructDef, mesh);
-      EM.ensureComponentOn(aabbEnt, ColorDef, ENDESGA16.orange);
+      EM.set(aabbEnt, RenderableConstructDef, mesh);
+      EM.set(aabbEnt, ColorDef, ENDESGA16.orange);
     }
 
     // BULLET VS COLLIDERS
@@ -738,7 +730,7 @@ export async function initShipyardGame(hosting: boolean) {
                     // vec3.zero(b.gravity);
                     if (_goodBallPool.numFree() > 0) {
                       // EM.ensureComponentOn(b, DeletedDef);
-                      EM.ensureComponentOn(b, DeadDef);
+                      EM.set(b, DeadDef);
                       spawnGoodBall(b.world.position);
                     } else {
                       breakBullet(b);
@@ -820,9 +812,9 @@ export async function initShipyardGame(hosting: boolean) {
           if (PhysicsParentDef.isOn(ball)) continue;
           // pick up this ball
           player.hsPlayer.holdingBall = ball.id;
-          EM.ensureComponentOn(ball, PhysicsParentDef, player.id);
+          EM.set(ball, PhysicsParentDef, player.id);
           vec3.set(0, 0, -1, ball.position);
-          EM.ensureComponentOn(ball, ScaleDef);
+          EM.set(ball, ScaleDef);
           vec3.copy(ball.scale, [0.8, 0.8, 0.8]);
           EM.removeComponent(ball.id, InteractableDef);
         }
@@ -838,13 +830,13 @@ export async function initShipyardGame(hosting: boolean) {
       g.controllable.sprintMul = 10;
       const sphereMesh = cloneMesh(res.allMeshes.ball.mesh);
       const visible = false;
-      EM.ensureComponentOn(g, RenderableConstructDef, sphereMesh, visible);
-      EM.ensureComponentOn(g, ColorDef, V(0.1, 0.1, 0.1));
-      EM.ensureComponentOn(g, PositionDef, V(0, 0, 0));
+      EM.set(g, RenderableConstructDef, sphereMesh, visible);
+      EM.set(g, ColorDef, V(0.1, 0.1, 0.1));
+      EM.set(g, PositionDef, V(0, 0, 0));
       // EM.ensureComponentOn(b2, PositionDef, [0, 0, -1.2]);
-      EM.ensureComponentOn(g, WorldFrameDef);
+      EM.set(g, WorldFrameDef);
       // EM.ensureComponentOn(b2, PhysicsParentDef, g.id);
-      EM.ensureComponentOn(g, ColliderDef, {
+      EM.set(g, ColliderDef, {
         shape: "AABB",
         solid: false,
         aabb: res.allMeshes.ball.aabb,

--- a/src/wood/pirate.ts
+++ b/src/wood/pirate.ts
@@ -404,7 +404,7 @@ const piratePool = createEntityPool<
       if (WoodHealthDef.isOn(timber) && PhysicsParentDef.isOn(timber)) {
         // TODO(@darzu): necessary?
         // timber.physicsParent.id = 0;
-        // EM.ensureComponentOn(timber, LifetimeDef, 1000);
+        // EM.set(timber, LifetimeDef, 1000);
         for (let b of timber.woodHealth.boards) {
           for (let s of b) {
             s.health = 0;

--- a/src/wood/pirate.ts
+++ b/src/wood/pirate.ts
@@ -129,7 +129,7 @@ export function appendPirateShip(b: TimberBuilder): RawMesh {
 const startDelay = 0;
 // const startDelay = 1000;
 
-export const PiratePlatformDef = EM.defineComponent(
+export const PiratePlatformDef = EM.defineNonupdatableComponent(
   "piratePlatform",
   (
     cannon: EntityW<[typeof PositionDef, typeof RotationDef]>,

--- a/src/wood/pirate.ts
+++ b/src/wood/pirate.ts
@@ -266,28 +266,24 @@ const piratePool = createEntityPool<
     const res = await EM.whenResources(AllMeshesDef, RendererDef, TimeDef);
     // make platform
     const platform = EM.new();
-    EM.ensureComponentOn(platform, ColorDef);
+    EM.set(platform, ColorDef);
     vec3.copy(platform.color, ENDESGA16.deepBrown);
-    EM.ensureComponentOn(platform, PositionDef);
-    EM.ensureComponentOn(platform, RotationDef);
+    EM.set(platform, PositionDef);
+    EM.set(platform, RotationDef);
     const groundMesh = cloneMesh(res.allMeshes.hex.mesh);
     transformMesh(
       groundMesh,
       mat4.fromRotationTranslationScale(quat.IDENTITY, [0, -1, 0], [4, 1, 4])
     );
-    EM.ensureComponentOn(platform, RenderableConstructDef, groundMesh);
+    EM.set(platform, RenderableConstructDef, groundMesh);
 
     // make cannon
     const cannon = EM.new();
-    EM.ensureComponentOn(
-      cannon,
-      RenderableConstructDef,
-      res.allMeshes.ld51_cannon.proto
-    );
-    EM.ensureComponentOn(cannon, PositionDef);
-    EM.ensureComponentOn(cannon, PhysicsParentDef, platform.id);
-    EM.ensureComponentOn(cannon, ColorDef, ENDESGA16.darkGray);
-    EM.ensureComponentOn(cannon, RotationDef);
+    EM.set(cannon, RenderableConstructDef, res.allMeshes.ld51_cannon.proto);
+    EM.set(cannon, PositionDef);
+    EM.set(cannon, PhysicsParentDef, platform.id);
+    EM.set(cannon, ColorDef, ENDESGA16.darkGray);
+    EM.set(cannon, RotationDef);
     vec3.copy(cannon.position, [0, 2, 0]);
 
     // make timber
@@ -307,23 +303,23 @@ const piratePool = createEntityPool<
     const timberMesh = _timberMesh as Mesh;
     timberMesh.usesProvoking = true;
     reserveSplinterSpace(timberState, 10);
-    EM.ensureComponentOn(timber, RenderableConstructDef, timberMesh);
-    EM.ensureComponentOn(timber, WoodStateDef, timberState);
-    EM.ensureComponentOn(timber, ColorDef, ENDESGA16.red);
+    EM.set(timber, RenderableConstructDef, timberMesh);
+    EM.set(timber, WoodStateDef, timberState);
+    EM.set(timber, ColorDef, ENDESGA16.red);
     const timberAABB = getAABBFromMesh(timberMesh);
-    EM.ensureComponentOn(timber, PositionDef, V(0, builder.width, 0));
-    EM.ensureComponentOn(timber, RotationDef);
-    EM.ensureComponentOn(timber, ColliderDef, {
+    EM.set(timber, PositionDef, V(0, builder.width, 0));
+    EM.set(timber, RotationDef);
+    EM.set(timber, ColliderDef, {
       shape: "AABB",
       solid: false,
       aabb: timberAABB,
     });
     const timberHealth = createWoodHealth(timberState);
-    EM.ensureComponentOn(timber, WoodHealthDef, timberHealth);
-    EM.ensureComponentOn(timber, PhysicsParentDef, platform.id);
+    EM.set(timber, WoodHealthDef, timberHealth);
+    EM.set(timber, PhysicsParentDef, platform.id);
 
     // make joint entity
-    EM.ensureComponentOn(platform, PiratePlatformDef, cannon, timber);
+    EM.set(platform, PiratePlatformDef, cannon, timber);
 
     return platform;
   },
@@ -385,14 +381,14 @@ const piratePool = createEntityPool<
     // pirateShip
     if (!DeadDef.isOn(e)) {
       // dead platform
-      EM.ensureComponentOn(e, DeadDef);
+      EM.set(e, DeadDef);
       if (RenderableDef.isOn(e)) e.renderable.hidden = true;
       e.dead.processed = true;
 
       // dead cannon
       if (e.piratePlatform.cannon()) {
         const c = e.piratePlatform.cannon()!;
-        EM.ensureComponentOn(c, DeadDef);
+        EM.set(c, DeadDef);
         if (RenderableDef.isOn(c)) c.renderable.hidden = true;
         c.dead.processed = true;
       }

--- a/src/wood/shipyard.ts
+++ b/src/wood/shipyard.ts
@@ -219,8 +219,8 @@ export async function dbgPathWithGizmos(path: Path) {
   const mesh = createPathGizmos(path);
 
   const e = EM.new();
-  EM.ensureComponentOn(e, PositionDef);
-  EM.ensureComponentOn(e, RenderableConstructDef, mesh);
+  EM.set(e, PositionDef);
+  EM.set(e, RenderableConstructDef, mesh);
 }
 
 function snapXToPath(path: Path, x: number, out: vec3) {

--- a/src/wood/wood-splinters.ts
+++ b/src/wood/wood-splinters.ts
@@ -23,9 +23,12 @@ export type SplinterPart = EntityW<[typeof PositionDef, typeof ColorDef]>;
 
 export type SplinterPool = ReturnType<typeof createSplinterPool>;
 
-export const SplinterParticleDef = EM.defineComponent("splinter", () => {
-  return {};
-});
+export const SplinterParticleDef = EM.defineNonupdatableComponent(
+  "splinter",
+  () => {
+    return {};
+  }
+);
 
 export const SplinterPoolsDef = EM.defineResource("splinterPools", () => {
   const _pools = new Map<string, SplinterPool>();

--- a/src/wood/wood-splinters.ts
+++ b/src/wood/wood-splinters.ts
@@ -79,7 +79,7 @@ function createSplinterPool(
     );
     const splinterMesh = normalizeMesh(_splinterMesh);
     const splinter = EM.new();
-    EM.ensureComponentOn(
+    EM.set(
       splinter,
       RenderableConstructDef,
       splinterMesh,
@@ -89,13 +89,13 @@ function createSplinterPool(
       undefined,
       true // hidden
     );
-    EM.ensureComponentOn(splinter, ColorDef);
-    EM.ensureComponentOn(splinter, PositionDef);
-    EM.ensureComponentOn(splinter, RotationDef);
-    EM.ensureComponentOn(splinter, AngularVelocityDef);
-    EM.ensureComponentOn(splinter, LinearVelocityDef);
-    EM.ensureComponentOn(splinter, GravityDef);
-    EM.ensureComponentOn(splinter, SplinterParticleDef);
+    EM.set(splinter, ColorDef);
+    EM.set(splinter, PositionDef);
+    EM.set(splinter, RotationDef);
+    EM.set(splinter, AngularVelocityDef);
+    EM.set(splinter, LinearVelocityDef);
+    EM.set(splinter, GravityDef);
+    EM.set(splinter, SplinterParticleDef);
     pool.push(splinter);
   }
 

--- a/src/wood/wood-splinters.ts
+++ b/src/wood/wood-splinters.ts
@@ -23,12 +23,9 @@ export type SplinterPart = EntityW<[typeof PositionDef, typeof ColorDef]>;
 
 export type SplinterPool = ReturnType<typeof createSplinterPool>;
 
-export const SplinterParticleDef = EM.defineNonupdatableComponent(
-  "splinter",
-  () => {
-    return {};
-  }
-);
+export const SplinterParticleDef = EM.defineComponent("splinter", () => {
+  return {};
+});
 
 export const SplinterPoolsDef = EM.defineResource("splinterPools", () => {
   const _pools = new Map<string, SplinterPool>();

--- a/src/wood/wood.ts
+++ b/src/wood/wood.ts
@@ -357,22 +357,17 @@ EM.addEagerInit([WoodStateDef], [], [], () => {
                 vec3.add(splinter.color, quadColor, splinter.color);
                 const pos = getLineMid(vec3.create(), seg.midLine);
                 vec3.transformMat4(pos, w.world.transform, pos);
-                EM.set(splinter, PositionDef);
-                vec3.copy(splinter.position, pos);
+                EM.set(splinter, PositionDef, pos);
                 const rot = getSegmentRotation(seg, false);
                 quat.mul(rot, w.world.rotation, rot); // TODO(@darzu): !VERIFY! this works
-                EM.set(splinter, RotationDef);
-                quat.copy(splinter.rotation, rot);
+                EM.set(splinter, RotationDef, rot);
                 const spin = randNormalVec3(vec3.create());
                 const vel = vec3.clone(spin);
                 vec3.scale(spin, 0.01, spin);
-                EM.set(splinter, AngularVelocityDef);
-                vec3.copy(splinter.angularVelocity, spin);
+                EM.set(splinter, AngularVelocityDef, spin);
                 vec3.scale(vel, 0.01, vel);
-                EM.set(splinter, LinearVelocityDef);
-                vec3.copy(splinter.linearVelocity, spin);
-                EM.set(splinter, GravityDef);
-                vec3.copy(splinter.gravity, [0, -3 * 0.00001, 0]);
+                EM.set(splinter, LinearVelocityDef, spin);
+                EM.set(splinter, GravityDef, [0, -3 * 0.00001, 0]);
               }
 
               if (h.prev && !h.prev.broken) {

--- a/src/wood/wood.ts
+++ b/src/wood/wood.ts
@@ -103,9 +103,12 @@ What does compute shader gain us?
 const __temp1 = vec3.create();
 const __temp2 = vec3.create();
 
-export const WoodStateDef = EM.defineComponent("woodState", (s: WoodState) => {
-  return s;
-});
+export const WoodStateDef = EM.defineNonupdatableComponent(
+  "woodState",
+  (s: WoodState) => {
+    return s;
+  }
+);
 
 export type WoodAssets = Partial<{
   [P in AllMeshSymbols]: WoodState;
@@ -1388,7 +1391,7 @@ export function unshareProvokingForWood(m: RawMesh, woodState: WoodState) {
   }
 }
 
-export const WoodHealthDef = EM.defineComponent(
+export const WoodHealthDef = EM.defineNonupdatableComponent(
   "woodHealth",
   (s: WoodHealth) => {
     return s;

--- a/src/wood/wood.ts
+++ b/src/wood/wood.ts
@@ -357,21 +357,21 @@ EM.addEagerInit([WoodStateDef], [], [], () => {
                 vec3.add(splinter.color, quadColor, splinter.color);
                 const pos = getLineMid(vec3.create(), seg.midLine);
                 vec3.transformMat4(pos, w.world.transform, pos);
-                EM.ensureComponentOn(splinter, PositionDef);
+                EM.set(splinter, PositionDef);
                 vec3.copy(splinter.position, pos);
                 const rot = getSegmentRotation(seg, false);
                 quat.mul(rot, w.world.rotation, rot); // TODO(@darzu): !VERIFY! this works
-                EM.ensureComponentOn(splinter, RotationDef);
+                EM.set(splinter, RotationDef);
                 quat.copy(splinter.rotation, rot);
                 const spin = randNormalVec3(vec3.create());
                 const vel = vec3.clone(spin);
                 vec3.scale(spin, 0.01, spin);
-                EM.ensureComponentOn(splinter, AngularVelocityDef);
+                EM.set(splinter, AngularVelocityDef);
                 vec3.copy(splinter.angularVelocity, spin);
                 vec3.scale(vel, 0.01, vel);
-                EM.ensureComponentOn(splinter, LinearVelocityDef);
+                EM.set(splinter, LinearVelocityDef);
                 vec3.copy(splinter.linearVelocity, spin);
-                EM.ensureComponentOn(splinter, GravityDef);
+                EM.set(splinter, GravityDef);
                 vec3.copy(splinter.gravity, [0, -3 * 0.00001, 0]);
               }
 
@@ -688,15 +688,11 @@ function createSplinterEnd(
     b.mesh.tri.forEach((_) => b.mesh.colors.push(vec3.clone(BLACK)));
   }
   const splinterMesh = normalizeMesh(_splinterMesh);
-  EM.ensureComponentOn(splinter, RenderableConstructDef, splinterMesh);
-  EM.ensureComponentOn(
-    splinter,
-    ColorDef,
-    V(Math.random(), Math.random(), Math.random())
-  );
-  EM.ensureComponentOn(splinter, PositionDef);
-  EM.ensureComponentOn(splinter, RotationDef);
-  EM.ensureComponentOn(splinter, WorldFrameDef);
+  EM.set(splinter, RenderableConstructDef, splinterMesh);
+  EM.set(splinter, ColorDef, V(Math.random(), Math.random(), Math.random()));
+  EM.set(splinter, PositionDef);
+  EM.set(splinter, RotationDef);
+  EM.set(splinter, WorldFrameDef);
   return splinter;
 }
 

--- a/todo.txt
+++ b/todo.txt
@@ -32,7 +32,7 @@ BIG FEATURES:
 [ ] TS static tools for refactor and perf
 
 QUALITY-OF-LIFE:
-[ ] EM usability
+[x] EM usability
   rename 'ensureComponentOn', 'registerSystem', 'registerInit'. These are used a ton and 
 [ ] Typed registries pattern
   Like how Assets and renderer{.stdPool, .grassPool, .oceanPool} provide nice typing, we should be able to figure out the right pattern so that we can have


### PR DESCRIPTION
We finally did it! EM.ensureComponentOn has been renamed to EM.set and it has the semantics you'd want. If the component isn't there, it creates it and sets it with provided params. If it is there, an update function is run.

The main change to enable this is that (most) components now have to define both an empty constructor and an update function.

However, for some components this isn't necessary if they use the EM.defineNonupdatableComponent call instead. This also lets you have required arguments at construction time. However NonupdatableComponents cannot have EM.set called on them multiple times and they also cannot be serialized or set over the network. They're good for local only stuff like GPU render state.